### PR TITLE
Update Reference Panels for SumstatGenCorr() via Zenodo

### DIFF
--- a/R/GXwasR_main_functions.R
+++ b/R/GXwasR_main_functions.R
@@ -6007,8 +6007,8 @@ LDPrune <- function(DataDir, finput, ResultDir = tempdir(), window_size = 50, st
 #' The number of cores to be used. The default is 2.
 #'
 #' @details
-#' This function requires access to the reference LD data via an environment variable.
-#' You must set one of the following environment variables to the appropriate directory:
+#' This function requires access to the \href{https://zenodo.org/records/16923484}{reference LD data} via an 
+#' environment variable. You must set one of the following environment variables to the appropriate directory:
 #'
 #' - `UKB_ARRAY_PATH` for the Axiom Array reference (`UKB_array_SVD_eigen90_extraction`)
 #' - `UKB_IMPUTED_PATH` for the full imputed reference (`UKB_imputed_SVD_eigen99_extraction`)

--- a/R/GXwasR_main_functions.R
+++ b/R/GXwasR_main_functions.R
@@ -6059,9 +6059,9 @@ SumstatGenCorr <- function(ResultDir = tempdir(),
     )
 
     reference_urls <- c(
-        UKB_imputed_hapmap2_SVD_eigen99_extraction = "https://www.dropbox.com/s/kv5zhgu274wg9z5/UKB_imputed_hapmap2_SVD_eigen99_extraction.tar.gz?dl=1",
-        UKB_imputed_SVD_eigen99_extraction = "https://www.dropbox.com/s/6js1dzy4tkc3gac/UKB_imputed_SVD_eigen99_extraction.tar.gz?dl=1",
-        UKB_array_SVD_eigen90_extraction = "https://www.dropbox.com/s/fuvpwsf6r8tjd6c/UKB_array_SVD_eigen90_extraction.tar.gz?dl=1"
+        UKB_imputed_hapmap2_SVD_eigen99_extraction = "https://zenodo.org/records/16923484/files/UKB_imputed_hapmap2_SVD_eigen99_extraction.tar.gz?download=1",
+        UKB_imputed_SVD_eigen99_extraction = "https://zenodo.org/records/16923484/files/UKB_imputed_hapmap2_SVD_eigen99_extraction.tar.gz?download=1",
+        UKB_array_SVD_eigen90_extraction = "https://zenodo.org/records/16923484/files/UKB_array_SVD_eigen90_extraction.tar.gz?download=1"
     )
 
     if (!referenceLD %in% names(reference_paths)) {

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -38,7 +38,6 @@ CHD
 CHR
 CHRY
 CHS
-CMD
 COV
 Cardon
 Cheng
@@ -384,6 +383,7 @@ ploygenic
 polygenic
 poolr
 pre
+prs
 pval
 pvalue
 quantitative’

--- a/man/SumstatGenCorr.Rd
+++ b/man/SumstatGenCorr.Rd
@@ -72,8 +72,8 @@ This function calculates the genetic correlation between two summary statistics
 using a specified reference linkage disequilibrium (LD) matrix from the UK Biobank.
 }
 \details{
-This function requires access to the reference LD data via an environment variable.
-You must set one of the following environment variables to the appropriate directory:
+This function requires access to the \href{https://zenodo.org/records/16923484}{reference LD data} via an
+environment variable. You must set one of the following environment variables to the appropriate directory:
 \itemize{
 \item \code{UKB_ARRAY_PATH} for the Axiom Array reference (\code{UKB_array_SVD_eigen90_extraction})
 \item \code{UKB_IMPUTED_PATH} for the full imputed reference (\code{UKB_imputed_SVD_eigen99_extraction})


### PR DESCRIPTION
## Overview

This PR implements requested changes from the Bioconductor review team regarding the reference panels used by `SumstatGenCorr()`. The panels are now hosted securely on Zenodo and referenced from the following record:

- [https://zenodo.org/records/16923484](https://zenodo.org/records/16923484)