### PR TITLE
Fix LaTeX Unicode errors in .Rd documentation

### DIFF
--- a/R/GXwasR_helper_functions.R
+++ b/R/GXwasR_helper_functions.R
@@ -935,13 +935,12 @@ applySNPmissCCFilter <- function(ResultDir, SNPmissCC, diffmissFilter, foutput) 
 
 ## Function 36
 #' @importFrom ggplot2 element_rect expansion
-gmirror <- function(
-        top, bottom, tline, bline, chroms = c(seq_len(22), "X", "Y"), log10 = TRUE,
-        yaxis, opacity = 1, annotate_snp, annotate_p, toptitle = NULL,
-        bottomtitle = NULL, highlight_snp, highlight_p, highlighter = "red",
-        chrcolor1 = "#AAAAAA", chrcolor2 = "#4D4D4D", freey = FALSE,
-        background = "variegated", chrblocks = FALSE, file = "gmirror",
-        type = "png", hgt = 7, hgtratio = 0.5, wi = 12, res = 300) {
+gmirror <- function(top, bottom, tline, bline, chroms = c(seq_len(22), "X", "Y"), log10 = TRUE,
+    yaxis, opacity = 1, annotate_snp, annotate_p, toptitle = NULL,
+    bottomtitle = NULL, highlight_snp, highlight_p, highlighter = "red",
+    chrcolor1 = "#AAAAAA", chrcolor2 = "#4D4D4D", freey = FALSE,
+    background = "variegated", chrblocks = FALSE, file = "gmirror",
+    type = "png", hgt = 7, hgtratio = 0.5, wi = 12, res = 300) {
     # Sort data
     topn <- names(top)
     bottomn <- names(bottom)
@@ -1430,9 +1429,11 @@ FMsub <- function(ResultDir, plot.jpeg, plotname, snp_pval, annotateTopSnp, sugg
 
 ## Function 46
 ## Added in 3.0
-paraGwas <- function(chunks, chunk, ResultDir, DataDir, finput, trait, modelv, regress, standard_b, noxsexv, sexv,
-    interactionv, parameterv, Inphenocovv, covar, covarv,
-    snpfile) {
+paraGwas <- function(
+      chunks, chunk, ResultDir, DataDir, finput, trait, modelv, regress, standard_b, noxsexv, sexv,
+      interactionv, parameterv, Inphenocovv, covar, covarv,
+      snpfile
+) {
     ## Chunkfile create
     rlang::inform(rlang::format_error_bullets(paste0("Chunk index processing: ", chunks)))
     if (nrow(snpfile) >= (chunks + chunk)) {
@@ -1492,9 +1493,8 @@ paraGwas <- function(chunks, chunk, ResultDir, DataDir, finput, trait, modelv, r
 
 ## Function 47
 ## Updated in 3.0
-FMmain <- function(
-        DataDir, ResultDir, finput, trait, standard_beta, xmodel,
-        sex, xsex, covarfile, interaction, covartest, Inphenocov, plot.jpeg, plotname, snp_pval, annotateTopSnp, suggestiveline, genomewideline, ncores) {
+FMmain <- function(DataDir, ResultDir, finput, trait, standard_beta, xmodel,
+    sex, xsex, covarfile, interaction, covartest, Inphenocov, plot.jpeg, plotname, snp_pval, annotateTopSnp, suggestiveline, genomewideline, ncores) {
     if (xmodel[1] == "FMcombx01" | xmodel[1] == "FMstratified") {
         modelv <- 1
     } else if (xmodel[1] == "FMcombx02") {
@@ -1662,16 +1662,15 @@ fisher.sum <- function(p, zero.sub = 0.00001, na.rm = FALSE) {
 ## Function 49
 # Copied from ex-CRAN package MADAM and exported. The man pages are copied from the original package.
 fisher.method <-
-    function(
-        pvals,
-        method = c("fisher"),
-        p.corr = c(
-            "bonferroni", "BH",
-            "none"
-        ),
-        zero.sub = 0.00001,
-        na.rm = FALSE,
-        mc.cores = NULL) {
+    function(pvals,
+    method = c("fisher"),
+    p.corr = c(
+        "bonferroni", "BH",
+        "none"
+    ),
+    zero.sub = 0.00001,
+    na.rm = FALSE,
+    mc.cores = NULL) {
         stopifnot(method %in% c("fisher"))
         stopifnot(p.corr %in% c("none", "bonferroni", "BH"))
         stopifnot(all(pvals >= 0, na.rm = TRUE) &
@@ -1715,13 +1714,12 @@ fisher.method <-
 ## Function 50
 # Copied from ex-CRAN package MADAM and exported. The man pages are copied from the original package.
 fisher.method.perm <-
-    function(
-        pvals,
-        p.corr = c("bonferroni", "BH", "none"),
-        zero.sub = 0.00001,
-        B = 10000,
-        mc.cores = NULL,
-        blinker = 1000) {
+    function(pvals,
+    p.corr = c("bonferroni", "BH", "none"),
+    zero.sub = 0.00001,
+    B = 10000,
+    mc.cores = NULL,
+    blinker = 1000) {
         stopifnot(is.na(blinker) || blinker > 0)
         stopifnot(p.corr %in% c("none", "bonferroni", "BH"))
         stopifnot(all(pvals >= 0, na.rm = TRUE) &
@@ -1781,16 +1779,15 @@ fisher.method.perm <-
 
 ## Function 51
 stouffer.method <-
-    function(
-        pvals,
-        method = c("stouffer"),
-        p.corr = c(
-            "bonferroni", "BH",
-            "none"
-        ),
-        zero.sub = 0.00001,
-        na.rm = FALSE,
-        mc.cores = NULL) {
+    function(pvals,
+    method = c("stouffer"),
+    p.corr = c(
+        "bonferroni", "BH",
+        "none"
+    ),
+    zero.sub = 0.00001,
+    na.rm = FALSE,
+    mc.cores = NULL) {
         stopifnot(method %in% c("stouffer"))
         stopifnot(p.corr %in% c("none", "bonferroni", "BH"))
         stopifnot(all(pvals >= 0, na.rm = TRUE) &
@@ -1839,16 +1836,15 @@ paraStouffer <- function(chunks, chunk, pvals, MF.p.corr, MF.zero.sub, MF.na.rm)
         pval_chunk <- pvals[chunks:nrow(pvals), ]
     }
     stouffer.method <-
-        function(
-        pvals,
-        method = c("stouffer"),
-        p.corr = c(
-            "bonferroni", "BH",
-            "none"
-        ),
-        zero.sub = 0.00001,
-        na.rm = FALSE,
-        mc.cores = NULL) {
+        function(pvals,
+    method = c("stouffer"),
+    p.corr = c(
+        "bonferroni", "BH",
+        "none"
+    ),
+    zero.sub = 0.00001,
+    na.rm = FALSE,
+    mc.cores = NULL) {
             stopifnot(method %in% c("stouffer"))
             stopifnot(p.corr %in% c("none", "bonferroni", "BH"))
             stopifnot(all(pvals >= 0, na.rm = TRUE) &
@@ -2194,19 +2190,18 @@ createPlots <- function(ResultDir, plotname, FemaleWAS, MaleWAS, gwas.t2, gwas.b
 
 ## Function 56
 ###### Updated in 3.0
-FMcomb_sub <- function(
-        ResultDir, combtest, MF.p.corr,
-        MF.zero.sub,
-        MF.na.rm,
-        MF.mc.cores,
-        B,
-        plot.jpeg,
-        plotname,
-        snp_pval,
-        annotateTopSnp,
-        suggestiveline,
-        genomewideline,
-        ncores) {
+FMcomb_sub <- function(ResultDir, combtest, MF.p.corr,
+    MF.zero.sub,
+    MF.na.rm,
+    MF.mc.cores,
+    B,
+    plot.jpeg,
+    plotname,
+    snp_pval,
+    annotateTopSnp,
+    suggestiveline,
+    genomewideline,
+    ncores) {
     load(normalizePath(file.path(ResultDir, "MaleWAS.Rda"), mustWork = FALSE))
     MaleWAS <- data.table::as.data.table(MaleWAS)
     gc(reset = TRUE)
@@ -2342,29 +2337,28 @@ FMcomb_sub <- function(
 
 ## Function 57
 ## Updated in 3.0
-FMcomb <- function(
-        DataDir,
-        ResultDir,
-        trait,
-        standard_beta,
-        xmodel,
-        covarfile,
-        covartest,
-        interaction,
-        Inphenocov,
-        combtest,
-        B,
-        MF.p.corr,
-        MF.zero.sub,
-        MF.na.rm,
-        MF.mc.cores,
-        plot.jpeg,
-        plotname,
-        snp_pval,
-        annotateTopSnp,
-        suggestiveline,
-        genomewideline,
-        ncores) {
+FMcomb <- function(DataDir,
+    ResultDir,
+    trait,
+    standard_beta,
+    xmodel,
+    covarfile,
+    covartest,
+    interaction,
+    Inphenocov,
+    combtest,
+    B,
+    MF.p.corr,
+    MF.zero.sub,
+    MF.na.rm,
+    MF.mc.cores,
+    plot.jpeg,
+    plotname,
+    snp_pval,
+    annotateTopSnp,
+    suggestiveline,
+    genomewideline,
+    ncores) {
     gc(reset = TRUE)
     # Here DataDir becomes ResultDir, need to put the covarfile always in ResultDir by copying
     if (!is.null(covarfile)) {
@@ -2420,9 +2414,8 @@ FMcomb <- function(
 
 ## Function 58
 ## Added in 3.0
-paraGwasAuto <- function(
-        chunks, chunk, ResultDir, finput, regress, sexv, noxsexv, interactionv, standard_b, parameterv, Inphenocovv, covar, covarv,
-        snpfile) {
+paraGwasAuto <- function(chunks, chunk, ResultDir, finput, regress, sexv, noxsexv, interactionv, standard_b, parameterv, Inphenocovv, covar, covarv,
+    snpfile) {
     ## Chunkfile create
     if (nrow(snpfile) >= (chunks + chunk)) {
         snp_names <- snpfile$V2[chunks:(chunks + chunk)]
@@ -2935,11 +2928,10 @@ removePatternFiles <- function(ResultDir, patterns) {
 
 ## Function 68
 ## Updated in 3.0
-XCMAFun <- function(
-        DataDir, ResultDir, finput, standard_beta,
-        covarfile, sex, covartest, interaction, Inphenocov, plot.jpeg, plotname, snp_pval,
-        annotateTopSnp, suggestiveline = suggestiveline, genomewideline = genomewideline,
-        ncores = ncores) {
+XCMAFun <- function(DataDir, ResultDir, finput, standard_beta,
+    covarfile, sex, covartest, interaction, Inphenocov, plot.jpeg, plotname, snp_pval,
+    annotateTopSnp, suggestiveline = suggestiveline, genomewideline = genomewideline,
+    ncores = ncores) {
     # Prepare data and get necessary files
     file_path <- normalizePath(file.path(ResultDir, "sink_file.txt"), mustWork = FALSE)
 
@@ -3266,9 +3258,11 @@ executeGCTA <- function(ResultDir, args) {
 }
 
 ## Function 73
-ComputeGRMauto <- function(DataDir, ResultDir, finput, partGRM, nGRM, cripticut,
-    minMAF = NULL, maxMAF = NULL,
-    ByCHR = FALSE, CHRnum = NULL, ncores = ncores) {
+ComputeGRMauto <- function(
+      DataDir, ResultDir, finput, partGRM, nGRM, cripticut,
+      minMAF = NULL, maxMAF = NULL,
+      ByCHR = FALSE, CHRnum = NULL, ncores = ncores
+) {
     autosome <- if (!ByCHR) "--autosome" else NULL
     chr <- if (ByCHR) "--chr" else NULL
 
@@ -3454,11 +3448,9 @@ ComputeGRMX <- function(DataDir, ResultDir, finput, partGRM, nGRM, minMAF = NULL
 }
 
 
-
 ## Function 75
-ComputeREMLone <- function(
-        DataDir, ResultDir, REMLalgo = c(0, 1, 2), nitr = 100, phenofile = NULL, cat_covarfile = NULL, quant_covarfile = NULL,
-        prevalence = 0.01, chr, grmfile, ncores) {
+ComputeREMLone <- function(DataDir, ResultDir, REMLalgo = c(0, 1, 2), nitr = 100, phenofile = NULL, cat_covarfile = NULL, quant_covarfile = NULL,
+    prevalence = 0.01, chr, grmfile, ncores) {
     if (is.null(phenofile)) {
         pheno <- NULL
         phenofile <- NULL
@@ -3555,9 +3547,8 @@ ComputeREMLone <- function(
 }
 
 ## Function 76
-ComputeREMLmulti <- function(
-        DataDir, ResultDir, REMLalgo = c(0, 1, 2), nitr = 100, phenofile = NULL, GE = FALSE, cat_covarfile = NULL, quant_covarfile = NULL,
-        prevalence = 0.01, grmfile = "multi_GRMs.txt", computeGRM = FALSE, grmfile_name = NULL, ncores = 2) {
+ComputeREMLmulti <- function(DataDir, ResultDir, REMLalgo = c(0, 1, 2), nitr = 100, phenofile = NULL, GE = FALSE, cat_covarfile = NULL, quant_covarfile = NULL,
+    prevalence = 0.01, grmfile = "multi_GRMs.txt", computeGRM = FALSE, grmfile_name = NULL, ncores = 2) {
     rlang::inform(rlang::format_error_bullets(c("i" = paste("computeGRM is set to:", computeGRM))))
 
     if (is.null(phenofile)) {
@@ -3715,9 +3706,8 @@ GettingGene <- function(gene_file, gene_range, SNP_bimfile, finput) {
 }
 
 ## Function 79
-ChrwiseLDprun <- function(
-        DataDir, ResultDir, finput, chromosome, highLD_regions, IndepSNP_window_size,
-        IndepSNP_step_size, IndepSNP_r2_threshold) {
+ChrwiseLDprun <- function(DataDir, ResultDir, finput, chromosome, highLD_regions, IndepSNP_window_size,
+    IndepSNP_step_size, IndepSNP_r2_threshold) {
     if (is.null(highLD_regions)) {
         highLD_regions <- NULL
         excludev <- NULL
@@ -4288,14 +4278,14 @@ getCI <- function(mn1, se1, method) {
 topForestplot <- function(i, MR2, Sbeta) {
     # Extract the SNP row
     SNPs <- MR2$SNP[i]
-    Fixed_Effect    <- MR2[i, c("BETA",      "CIfixedLL",   "CIfixedUL")]
-    Random_Effect   <- MR2[i, c("BETA.R.",   "CIrandomLL",  "CIrandomUL")]
-    Weighted_Effect <- MR2[i, c("WEIGHTED_Z","CIweightedLL","CIweightedUL")]
-    
+    Fixed_Effect <- MR2[i, c("BETA", "CIfixedLL", "CIfixedUL")]
+    Random_Effect <- MR2[i, c("BETA.R.", "CIrandomLL", "CIrandomUL")]
+    Weighted_Effect <- MR2[i, c("WEIGHTED_Z", "CIweightedLL", "CIweightedUL")]
+
     # Collect per-study estimates
     Study_EFFect <- Sbeta[Sbeta$SNP == SNPs, , drop = FALSE]
-    Study_EFFect <- Study_EFFect[, -1]  # drop SNP column
-    
+    Study_EFFect <- Study_EFFect[, -1] # drop SNP column
+
     # Combine all rows
     D1 <- rbind(
         Study_EFFect,
@@ -4304,25 +4294,25 @@ topForestplot <- function(i, MR2, Sbeta) {
         Weighted_Effect,
         use.names = FALSE
     )
-    
+
     # Add labels + reorder
-    D1$V2    <- row.names(D1)
+    D1$V2 <- row.names(D1)
     D1$index <- as.integer(D1$V2)
     D1$study <- paste0("S", D1$index)
-    D1       <- D1[, c(6, 5, seq_len(3))]
+    D1 <- D1[, c(6, 5, seq_len(3))]
     colnames(D1) <- c("study", "index", "effect", "lower", "upper")
-    
+
     # Relabel last three rows
-    D1[nrow(D1),   "study"] <- "W"
-    D1[nrow(D1)-1, "study"] <- "R"
-    D1[nrow(D1)-2, "study"] <- "F"
-    
+    D1[nrow(D1), "study"] <- "W"
+    D1[nrow(D1) - 1, "study"] <- "R"
+    D1[nrow(D1) - 2, "study"] <- "F"
+
     # For ordering: keep studies at bottom, meta rows at top
     D1$study <- factor(D1$study, levels = rev(D1$study))
-    
+
     # Add aesthetics for color and size
     D1$group <- ifelse(D1$study %in% c("F", "R", "W"), "meta", "study")
-    
+
     # ---- build ggplot ----
     p <- ggplot(D1, aes(x = .data$effect, y = .data$study)) +
         geom_vline(xintercept = 0, linetype = 2, color = "grey50") +
@@ -4338,7 +4328,7 @@ topForestplot <- function(i, MR2, Sbeta) {
         geom_point(aes(shape = .data$group, color = .data$group, size = .data$group)) +
         scale_color_manual(values = c(study = "black", meta = "blue")) +
         scale_shape_manual(values = c(study = 19, meta = 18)) +
-        scale_size_manual(values  = c(study = 2, meta = 3.5)) +
+        scale_size_manual(values = c(study = 2, meta = 3.5)) +
         labs(
             title = SNPs,
             x = "Effect size (beta, 95% CI)",
@@ -4350,7 +4340,7 @@ topForestplot <- function(i, MR2, Sbeta) {
             legend.position = "none",
             plot.title = element_text(hjust = 0.5)
         )
-    
+
     return(p)
 }
 
@@ -4511,22 +4501,23 @@ metaFun <- function(DataDir, ResultDir, SummData, CHR, chromosome, nomap, UseA1v
 ## Function 94
 # Added in 3.0
 generatePlots <- function(MRfiltered, Sbeta, ResultDir, plotname,
-                          useSNPposition, pval_threshold_manplot,
-                          chosen_snps_file) {
+    useSNPposition, pval_threshold_manplot,
+    chosen_snps_file) {
     # Determine the number of SNPs to plot
     numSNPs <- min(length(unique(MRfiltered$SNP)), 10)
     if (length(unique(MRfiltered$SNP)) > 10) {
         rlang::inform(rlang::format_error_bullets(c(
-            "i" = "Maximum 10 Forest plots of 10 chosen SNPs will be returned. 
+            "i" = "Maximum 10 Forest plots of 10 chosen SNPs will be returned.
                    For all other Forest plots, please check ResultDir."
         )))
     }
 
     # Generate forest plots and collect them
     plots <- lapply(seq_len(numSNPs),
-                    topForestplot,
-                    MR2 = MRfiltered,
-                    Sbeta = Sbeta)
+        topForestplot,
+        MR2 = MRfiltered,
+        Sbeta = Sbeta
+    )
 
     # Add a label about what kind of plots these are
     attr(plots, "description") <- if (is.null(chosen_snps_file)) {
@@ -4539,8 +4530,10 @@ generatePlots <- function(MRfiltered, Sbeta, ResultDir, plotname,
 }
 
 ## Function 95
-ComputeBivarREMLone <- function(DataDir, ResultDir, REMLalgo = c(0, 1, 2), nitr = 100, phenofile, cat_covarfile = NULL,
-    quant_covarfile = NULL, grmfile = "GXwasR", excludeResidual = c("FALSE", "TRUE"), chr, ncores = 2) {
+ComputeBivarREMLone <- function(
+      DataDir, ResultDir, REMLalgo = c(0, 1, 2), nitr = 100, phenofile, cat_covarfile = NULL,
+      quant_covarfile = NULL, grmfile = "GXwasR", excludeResidual = c("FALSE", "TRUE"), chr, ncores = 2
+) {
     if (excludeResidual == "FALSE") {
         ExResi <- NULL
     } else {
@@ -4633,9 +4626,8 @@ ComputeBivarREMLone <- function(DataDir, ResultDir, REMLalgo = c(0, 1, 2), nitr 
 }
 
 ## Function 96
-ComputeBivarREMLmulti <- function(
-        DataDir, ResultDir, REMLalgo = c(0, 1, 2), nitr = 100, phenofile, cat_covarfile = NULL,
-        quant_covarfile = NULL, grmfile = "multi_GRMs.txt", excludeResidual = c("FALSE", "TRUE"), computeGRM = FALSE, grmfile_name = NULL, ncores = 2) {
+ComputeBivarREMLmulti <- function(DataDir, ResultDir, REMLalgo = c(0, 1, 2), nitr = 100, phenofile, cat_covarfile = NULL,
+    quant_covarfile = NULL, grmfile = "multi_GRMs.txt", excludeResidual = c("FALSE", "TRUE"), computeGRM = FALSE, grmfile_name = NULL, ncores = 2) {
     rlang::inform(rlang::format_error_bullets(c("i" = paste("computeGRM is set to:", computeGRM))))
 
     if (excludeResidual == "FALSE") {
@@ -5330,10 +5322,9 @@ processLDreferenceData <- function(ResultDir, highLD_regions, referLD, referLD_w
 }
 
 ## Function 103
-filterATGCSNPs <- function(
-        study_bim_path, study_bed_path, study_fam_path,
-        ref_bim_path, ref_bed_path, ref_fam_path,
-        ResultDir) {
+filterATGCSNPs <- function(study_bim_path, study_bed_path, study_fam_path,
+    ref_bim_path, ref_bed_path, ref_fam_path,
+    ResultDir) {
     # Helper to identify ambiguous SNPs (A-T / G-C)
     getAmbiguousSNPs <- function(bim_file) {
         bimData <- vroom::vroom(
@@ -5926,7 +5917,6 @@ runSKAT <- function(score.file, gene.file, genes, cor.path, gene_approximation, 
 # in SKAT0 or SKAT. All P values larger than skato_p_threshold will be processed via burden test. The default is 0.8
 
 
-
 ## Function 119
 ## Added in 3.0
 runSKATO <- function(score.file, gene.file, genes, cor.path, anno.type, gene_approximation, beta.par, weights.function, kernel_p_method, acc_devies, lim_devies, rho, skato_p_threshold) {
@@ -6163,18 +6153,17 @@ validateInputForQCsnp <- function(DataDir, ResultDir = tempdir(), finput, foutpu
 
 ## Function 129
 ## Added in 3.0
-validateInputForEstimateHerit <- function(
-        DataDir = NULL, ResultDir = tempdir(), finput = NULL,
-        summarystat = NULL, ncores = parallel::detectCores(),
-        model = c("LDSC", "GREML"), byCHR = FALSE, r2_LD = 0,
-        LDSC_blocks = 20, REMLalgo = c(0, 1, 2), nitr = 100,
-        cat_covarfile = NULL, quant_covarfile = NULL,
-        prevalence = 0.01, partGRM = FALSE, autosome = TRUE,
-        Xsome = TRUE, nGRM = 3, cripticut = 0.025,
-        minMAF = NULL, maxMAF = NULL, hg = c("hg19", "hg38"),
-        PlotIndepSNP = c(TRUE, FALSE), IndepSNP_window_size = 50,
-        IndepSNP_step_size = 5, IndepSNP_r2_threshold = 0.02,
-        highLD_regions = NULL) {
+validateInputForEstimateHerit <- function(DataDir = NULL, ResultDir = tempdir(), finput = NULL,
+    summarystat = NULL, ncores = parallel::detectCores(),
+    model = c("LDSC", "GREML"), byCHR = FALSE, r2_LD = 0,
+    LDSC_blocks = 20, REMLalgo = c(0, 1, 2), nitr = 100,
+    cat_covarfile = NULL, quant_covarfile = NULL,
+    prevalence = 0.01, partGRM = FALSE, autosome = TRUE,
+    Xsome = TRUE, nGRM = 3, cripticut = 0.025,
+    minMAF = NULL, maxMAF = NULL, hg = c("hg19", "hg38"),
+    PlotIndepSNP = c(TRUE, FALSE), IndepSNP_window_size = 50,
+    IndepSNP_step_size = 5, IndepSNP_r2_threshold = 0.02,
+    highLD_regions = NULL) {
     # Validate directories
     if (!is.null(DataDir) && !dir.exists(DataDir)) {
         stop("Error in DataDir: Directory does not exist.")
@@ -6182,7 +6171,6 @@ validateInputForEstimateHerit <- function(
     if (!is.null(ResultDir) && !dir.exists(ResultDir)) {
         stop("Error in ResultDir: Directory does not exist.")
     }
-
 
 
     # Validate summarystat if not NULL
@@ -7532,9 +7520,8 @@ read_plink_clumped_clean <- function(resultDir, filename) {
 ## Helper function from HDL R package ##
 #' @importFrom dplyr n
 HDL.rg <-
-    function(
-        gwas1.df, gwas2.df, LD.path, Nref = 335265, N0 = min(gwas1.df$N, gwas2.df$N), output.file = "", eigen.cut = "automatic",
-        jackknife.df = FALSE, intercept.output = FALSE, fill.missing.N = NULL, lim = exp(-18)) {
+    function(gwas1.df, gwas2.df, LD.path, Nref = 335265, N0 = min(gwas1.df$N, gwas2.df$N), output.file = "", eigen.cut = "automatic",
+    jackknife.df = FALSE, intercept.output = FALSE, fill.missing.N = NULL, lim = exp(-18)) {
         ## Initialize vars used later
         snps.list.imputed.vector <- NULL
         nsnps.list.imputed <- NULL
@@ -8286,7 +8273,6 @@ HDL.rg <-
     }
 
 
-
 .Random.seed <-
     c(
         403L, 624L, 481462074L, -1827783821L, -1227001320L, 540513593L,
@@ -8419,9 +8405,8 @@ HDL.rg <-
 
 #' @importFrom foreach %dopar%
 #' @importFrom dplyr row_number
-HDL.rg.parallel <- function(
-        gwas1.df, gwas2.df, LD.path, Nref = 335265, N0 = min(gwas1.df$N, gwas2.df$N), output.file = "", numCores = 2,
-        eigen.cut = "automatic", jackknife.df = FALSE, intercept.output = FALSE, fill.missing.N = NULL, lim = exp(-18)) {
+HDL.rg.parallel <- function(gwas1.df, gwas2.df, LD.path, Nref = 335265, N0 = min(gwas1.df$N, gwas2.df$N), output.file = "", numCores = 2,
+    eigen.cut = "automatic", jackknife.df = FALSE, intercept.output = FALSE, fill.missing.N = NULL, lim = exp(-18)) {
     ## Initialize vars used later
     snps.list.imputed.vector <- NULL
     nsnps.list.imputed <- NULL
@@ -9189,9 +9174,8 @@ HDL.rg.parallel <- function(
     return(list(rg = rg, rg.se = rg.se, P = P, estimates.df = estimates.df, eigen.use = eigen.use))
 }
 
-llfun.gcov.part.2 <- function(
-        param, h11, h22, rho12, M, N1, N2, N0, Nref,
-        lam0, lam1, lam2, bstar1, bstar2, lim = exp(-10)) {
+llfun.gcov.part.2 <- function(param, h11, h22, rho12, M, N1, N2, N0, Nref,
+    lam0, lam1, lam2, bstar1, bstar2, lim = exp(-10)) {
     h12 <- param[1]
     int <- param[2]
     ## sample fractions

--- a/R/GXwasR_main_functions.R
+++ b/R/GXwasR_main_functions.R
@@ -5371,10 +5371,10 @@ FilterAllele <- function(DataDir, ResultDir, finput, foutput) {
 #'
 #' @param combtest
 #' Character vector specifying method for combining p-values for stratified GWAS models. Choices are “stouffer.method”,
-#' "fisher.method" and "fisher.method.perm". For fisher.method the function for combining p-values uses a statistic,
-#' \eqn{S = -2 ∑^k /log p}, which follows a \eqn{χ^2} distribution with 2k degrees of freedom \insertCite{Fisher1925}{GXwasR}.
+#' "fisher.method" and "fisher.method.perm". For fisher.method, the function for combining p-values uses a statistic,
+#' \eqn{S = -2 \sum_{i=1}^{k} \log(p_i)}, which follows a \eqn{\chi^2} distribution with 2k degrees of freedom \insertCite{Fisher1925}{GXwasR}.
 #' For fisher.method.perm, using p-values from stratified tests, the summary statistic for combining p-values
-#' is \eqn{S = -2 ∑ /log p}. A p-value for this statistic can be derived by randomly generating summary statistics \insertCite{Rhodes2002}{GXwasR}.
+#' is \eqn{S = -2 \sum_{i=1}^{k} \log(p_i)}. A p-value for this statistic can be derived by randomly generating summary statistics \insertCite{Rhodes2002}{GXwasR}.
 #' Therefore, a p-value is randomly sampled from each contributing study, and a random statistic is calculated. The
 #' fraction of random statistics greater or equal to S then gives the final p-value.
 #'

--- a/R/GXwasR_main_functions.R
+++ b/R/GXwasR_main_functions.R
@@ -3589,17 +3589,17 @@ GXWASmiami <- function(ResultDir = tempdir(), FemaleWAS, MaleWAS, snp_pval = 1e-
 #' @param combtest
 #' Character vector specifying method for combining p-values after stratified GWAS/XWAS models.
 #' Choices are “stouffer.method”, "fisher.method" and "fisher.method.perm". For fisher.method the function for combining
-#' p-values uses a statistic, \eqn{S = -2 ∑^k /log p}, which follows a \eqn{χ^2} distribution with 2k degrees of freedom \insertCite{Fisher1925}{GXwasR}.
+#' p-values uses a statistic, \eqn{S = -2 \sum_{i=1}^{k} \log(p_i)}, which follows a \eqn{\chi^2} distribution with 2k degrees of freedom \insertCite{Fisher1925}{GXwasR}.
 #'
-#' For fisher.method.perm, using p-values from stratified tests, the summary statistic for combining p-values is \eqn{S = -2 ∑ /log p}.
+#' For fisher.method.perm, using p-values from stratified tests, the summary statistic for combining p-values is \eqn{S = -2 \sum_{i=1}^{k} \log(p_i)}.
 #' A p-value for this statistic can be derived by randomly generating summary statistics \insertCite{Rhodes2002}{GXwasR}. Therefore, a p-value is randomly
 #' sampled from each contributing study, and a random statistic is calculated. The fraction of random statistics greater or
 #' equal to S then gives the final p-value.
 #'
 #' For stouffer.method ,the function applies Stouffer’s method \insertCite{Stouffer1949}{GXwasR} to the p-values assuming that the p-values to be combined are
 #' independent. Letting p1, p2, . . . , pk denote the individual (one- or two-sided) p-values of the k hypothesis tests to be
-#' combined, the test statistic is then computed with \eqn{$z = ∑^k_{1}frac{z_{i}}{sqrt(k)}$} where \eqn{$z_{i}$ = Φ−1 (1 – $p_{i}$)} and
-#' \eqn{Φ −1 (·)} denotes the inverse of the cumulative distribution function of a standard normal distribution. Under the joint null
+#' combined, the test statistic is then computed as \eqn{z = \frac{\sum_{i=1}^{k} z_i}{\sqrt{k}}}, where \eqn{z_i = \Phi^{-1}(1 - p_i)} and
+#' \eqn{\Phi^{-1}(\cdot)} denotes the inverse of the cumulative distribution function of a standard normal distribution. Under the joint null
 #' hypothesis, the test statistic follows a standard normal distribution which is used to compute the combined p-value. This
 #' functionality is taken from the R package poolr \insertCite{Cinar2022}{GXwasR}.
 #'

--- a/R/GXwasR_main_functions.R
+++ b/R/GXwasR_main_functions.R
@@ -360,7 +360,7 @@ AncestryCheck <- function(DataDir,
 #' to their investigation.
 #'
 #' This function computes gene-wise SNP-SNP correlation matrices and can perform nine different gene-based tests, such as, “BT" (burden test),
-#' "SKAT" (sequence kernel association test), "SKATO" (combination of BT and SKAT), "sumchi" (sum of χ2-statistics), "ACAT" (aggregated
+#' "SKAT" (sequence kernel association test), "SKATO" (combination of BT and SKAT), "sumchi" (sum of \eqn{\chi^2}-statistics), "ACAT" (aggregated
 #' Cauchy association test for combining P values), "PCA"(principal component approach), "FLM"( functional multiple linear regression model),
 #' "simpleM" (Bonferroni correction test), "minp" (minimum P-value) leveraging PLINK1.9 \insertCite{Purcell2007}{GXwasR} and sumFREGAT
 #' \insertCite{Svishcheva2019,Belonogova2022}{GXwasR} tools.
@@ -4419,7 +4419,7 @@ ClumpLD <- function(
 #'
 #' @description
 #' This function tests the null hypothesis that a measured statistics (example: genetic correlation,
-#' rg for a trait) < 1 using a 1-tailed test compared with a normal distribution (z = (1 − measure statistics)/Standard error).
+#' rg for a trait) < 1 using a 1-tailed test compared with a normal distribution (z = (1 - measure statistics)/Standard error).
 #' For multiple tests, users are encouraged to apply a Bonferroni multiple-testing correction.
 #'
 #' @param inputdata
@@ -4499,12 +4499,12 @@ DiffZeroOne <- function(inputdata, diffzero = TRUE, diffone = TRUE) {
 #'
 #' @description
 #' This function calculates the difference in any kind of measured entities,(example: including SNP heritability estimate,
-#' genetic correlation, and GWAS β values) between sexes using a Z-score and its associated p-value statistic.
+#' genetic correlation, and GWAS \eqn{\beta} values) between sexes using a Z-score and its associated p-value statistic.
 #' When STAT/SE is normally distributed and the test statistics are independent in sex, the test is well calibrated. If
 #' the statistics are positively correlated, this test is conservative (1).
 #'
 #' We could define SNPs with SDEs as those variants at the extreme ends of the distribution with an absolute value of the
-#' Z-score greater than 3(|Z-score| > 3), which is roughly equivalent to p <10−3, and represents 0.3% of all tested SNPs.
+#' Z-score greater than 3(|Z-score| > 3), which is roughly equivalent to p <10-3, and represents 0.3% of all tested SNPs.
 #' The input dataframes should only include X-chromosome in order to obtain results for sex differences based solely on
 #' X-linked loci.
 #'

--- a/R/GXwasR_main_functions.R
+++ b/R/GXwasR_main_functions.R
@@ -122,24 +122,26 @@
 #'     study_pop = study_pop, studyLD = studyLD, referLD = referLD,
 #'     outlierOf = "EUR", outlier = outlier, outlier_threshold = outlier_threshold
 #' )
-AncestryCheck <- function(DataDir,
-    ResultDir = tempdir(),
-    finput,
-    reference = c("HapMapIII_NCBI36", "ThousandGenome"),
-    filterSNP = TRUE,
-    studyLD = TRUE,
-    studyLD_window_size = 50,
-    studyLD_step_size = 5,
-    studyLD_r2_threshold = 0.02,
-    referLD = FALSE,
-    referLD_window_size = 50,
-    referLD_step_size = 5,
-    referLD_r2_threshold = 0.02,
-    highLD_regions,
-    study_pop,
-    outlier = FALSE,
-    outlierOf = "EUR",
-    outlier_threshold = 3) {
+AncestryCheck <- function(
+      DataDir,
+      ResultDir = tempdir(),
+      finput,
+      reference = c("HapMapIII_NCBI36", "ThousandGenome"),
+      filterSNP = TRUE,
+      studyLD = TRUE,
+      studyLD_window_size = 50,
+      studyLD_step_size = 5,
+      studyLD_r2_threshold = 0.02,
+      referLD = FALSE,
+      referLD_window_size = 50,
+      referLD_step_size = 5,
+      referLD_r2_threshold = 0.02,
+      highLD_regions,
+      study_pop,
+      outlier = FALSE,
+      outlierOf = "EUR",
+      outlier_threshold = 3
+) {
     tryCatch(
         {
             # Validate inputs
@@ -576,46 +578,48 @@ AncestryCheck <- function(DataDir,
 #'         omit_linear_variant
 #'     )
 #' }
-TestXGene <- function(DataDir,
-    ResultDir = tempdir(),
-    finput,
-    sumstat,
-    gene_file,
-    gene_range = 500000,
-    score_file,
-    ref_data = NULL,
-    max_gene = NULL,
-    sample_size = NULL,
-    genebasedTest = c(
-        "SKAT",
-        "SKATO",
-        "sumchi",
-        "ACAT",
-        "BT",
-        "PCA",
-        "FLM",
-        "simpleM",
-        "minp"
-    ),
-    gene_approximation = TRUE,
-    beta_par,
-    weights_function,
-    geno_variance_weights,
-    kernel_p_method = "kuonen",
-    acc_devies = 1e-8,
-    lim_devies = 1e+6,
-    rho = TRUE,
-    skato_p_threshold = 0.8,
-    anno_type = "",
-    mac_threshold,
-    reference_matrix_used,
-    regularize_fun,
-    pca_var_fraction = 0.85,
-    flm_basis_function = "fourier",
-    flm_num_basis = 25,
-    flm_poly_order = 4,
-    flip_genotypes = FALSE,
-    omit_linear_variant = FALSE) {
+TestXGene <- function(
+      DataDir,
+      ResultDir = tempdir(),
+      finput,
+      sumstat,
+      gene_file,
+      gene_range = 500000,
+      score_file,
+      ref_data = NULL,
+      max_gene = NULL,
+      sample_size = NULL,
+      genebasedTest = c(
+          "SKAT",
+          "SKATO",
+          "sumchi",
+          "ACAT",
+          "BT",
+          "PCA",
+          "FLM",
+          "simpleM",
+          "minp"
+      ),
+      gene_approximation = TRUE,
+      beta_par,
+      weights_function,
+      geno_variance_weights,
+      kernel_p_method = "kuonen",
+      acc_devies = 1e-8,
+      lim_devies = 1e+6,
+      rho = TRUE,
+      skato_p_threshold = 0.8,
+      anno_type = "",
+      mac_threshold,
+      reference_matrix_used,
+      regularize_fun,
+      pca_var_fraction = 0.85,
+      flm_basis_function = "fourier",
+      flm_num_basis = 25,
+      flm_poly_order = 4,
+      flip_genotypes = FALSE,
+      omit_linear_variant = FALSE
+) {
     tryCatch(
         withCallingHandlers(
             {
@@ -1017,27 +1021,26 @@ SexDiff <- function(Mfile, Ffile) {
 #'     caldiffmiss = caldiffmiss
 #' )
 QCsnp <-
-    function(
-        DataDir,
-        ResultDir = tempdir(),
-        finput,
-        foutput = "FALSE",
-        casecontrol = TRUE,
-        hweCase = NULL,
-        hweControl = NULL,
-        hwe = NULL,
-        maf = 0.05,
-        geno = 0.1,
-        monomorphicSNPs = FALSE,
-        caldiffmiss = FALSE,
-        diffmissFilter = FALSE,
-        dmissX = FALSE,
-        dmissAutoY = FALSE,
-        highLD_regions = NULL,
-        ld_prunning = FALSE,
-        window_size = 50,
-        step_size = 5,
-        r2_threshold = 0.02) {
+    function(DataDir,
+    ResultDir = tempdir(),
+    finput,
+    foutput = "FALSE",
+    casecontrol = TRUE,
+    hweCase = NULL,
+    hweControl = NULL,
+    hwe = NULL,
+    maf = 0.05,
+    geno = 0.1,
+    monomorphicSNPs = FALSE,
+    caldiffmiss = FALSE,
+    diffmissFilter = FALSE,
+    dmissX = FALSE,
+    dmissAutoY = FALSE,
+    highLD_regions = NULL,
+    ld_prunning = FALSE,
+    window_size = 50,
+    step_size = 5,
+    r2_threshold = 0.02) {
         if (!validateInputForQCsnp(DataDir, ResultDir, finput, foutput, casecontrol, hweCase, hweControl, hwe, maf, geno, monomorphicSNPs, caldiffmiss, diffmissFilter, dmissX, dmissAutoY, highLD_regions, ld_prunning, window_size, step_size, r2_threshold)) {
             return(NULL)
         }
@@ -1365,17 +1368,16 @@ QCsnp <-
 #'     IndepSNP_window_size = 50, IndepSNP_step_size = 5, IndepSNP_r2_threshold = 0.02,
 #'     highLD_regions = highLD_hg19
 #' )
-EstimateHerit <- function(
-        DataDir = NULL, ResultDir = tempdir(), finput = NULL, precomputedLD = NULL,
-        indepSNPs = NULL, summarystat = NULL, ncores = 2, model = c("LDSC", "GREML"),
-        computeGRM = TRUE, grmfile_name = NULL, byCHR = FALSE,
-        r2_LD = 0, LDSC_blocks = 20, intercept = NULL, chi2_thr1 = 30,
-        chi2_thr2 = Inf, REMLalgo = c(0, 1, 2), nitr = 100, cat_covarfile = NULL,
-        quant_covarfile = NULL, prevalence = NULL, partGRM = FALSE, autosome = TRUE,
-        Xsome = TRUE, nGRM = 3, cripticut = 0.025, minMAF = NULL, maxMAF = NULL,
-        hg = c("hg19", "hg38"), PlotIndepSNP = TRUE, IndepSNP_window_size = 50,
-        IndepSNP_step_size = 5, IndepSNP_r2_threshold = 0.02, highLD_regions = NULL,
-        plotjpeg = TRUE, plotname = "Heritability_Plots") {
+EstimateHerit <- function(DataDir = NULL, ResultDir = tempdir(), finput = NULL, precomputedLD = NULL,
+    indepSNPs = NULL, summarystat = NULL, ncores = 2, model = c("LDSC", "GREML"),
+    computeGRM = TRUE, grmfile_name = NULL, byCHR = FALSE,
+    r2_LD = 0, LDSC_blocks = 20, intercept = NULL, chi2_thr1 = 30,
+    chi2_thr2 = Inf, REMLalgo = c(0, 1, 2), nitr = 100, cat_covarfile = NULL,
+    quant_covarfile = NULL, prevalence = NULL, partGRM = FALSE, autosome = TRUE,
+    Xsome = TRUE, nGRM = 3, cripticut = 0.025, minMAF = NULL, maxMAF = NULL,
+    hg = c("hg19", "hg38"), PlotIndepSNP = TRUE, IndepSNP_window_size = 50,
+    IndepSNP_step_size = 5, IndepSNP_r2_threshold = 0.02, highLD_regions = NULL,
+    plotjpeg = TRUE, plotname = "Heritability_Plots") {
     # Validate inputs
     if (!validateInputForEstimateHerit(DataDir, ResultDir, finput, summarystat, ncores, model, byCHR, r2_LD, LDSC_blocks, REMLalgo, nitr, cat_covarfile, quant_covarfile, prevalence, partGRM, autosome, Xsome, nGRM, cripticut, minMAF, maxMAF, hg, PlotIndepSNP, IndepSNP_window_size, IndepSNP_step_size, IndepSNP_r2_threshold, highLD_regions)) {
         return(NULL)
@@ -1431,7 +1433,6 @@ EstimateHerit <- function(
         }
     )
 }
-
 
 
 #' ComputeGeneticPC: Computing principal components from genetic relationship matrix
@@ -1506,9 +1507,11 @@ EstimateHerit <- function(
 #'     DataDir = DataDir, ResultDir = ResultDir,
 #'     finput = finput, highLD_regions = highLD_hg19, countPC = 20
 #' )
-ComputeGeneticPC <- function(DataDir, ResultDir = tempdir(), finput, countPC = 10, plotPC = TRUE,
-    highLD_regions = NULL, ld_prunning = TRUE,
-    window_size = 50, step_size = 5, r2_threshold = 0.02) {
+ComputeGeneticPC <- function(
+      DataDir, ResultDir = tempdir(), finput, countPC = 10, plotPC = TRUE,
+      highLD_regions = NULL, ld_prunning = TRUE,
+      window_size = 50, step_size = 5, r2_threshold = 0.02
+) {
     # Validate inputs
     if (!validateInputForComputeGeneticPC(DataDir, ResultDir, finput, countPC, plotPC, highLD_regions, ld_prunning, window_size, step_size, r2_threshold)) {
         stop("Please verify all inputs.")
@@ -1668,11 +1671,11 @@ ComputeGeneticPC <- function(DataDir, ResultDir = tempdir(), finput, countPC = 1
 #'
 #' @author Banabithi Bose
 #'
-#' @description This function calculates the polygenic risk score, which summarizes the estimated effect of many genetic variants on an 
-#' individual’s phenotype. It is calculated  as the sum of the allele counts (genotypes), each weighted by their estimated phenotypic 
-#' effect sizes from genome-wide association studies. It uses C+T filtering techniques. Users can perform the clumping procedure 
-#' chromosome-wise or genome-wide. Also, the function offers the choice of including genetic principal components and other covariates. 
-#' Using this function, users have freedom to experiment with various clumping and thresholding arrangements to test a wide range of 
+#' @description This function calculates the polygenic risk score, which summarizes the estimated effect of many genetic variants on an
+#' individual’s phenotype. It is calculated  as the sum of the allele counts (genotypes), each weighted by their estimated phenotypic
+#' effect sizes from genome-wide association studies. It uses C+T filtering techniques. Users can perform the clumping procedure
+#' chromosome-wise or genome-wide. Also, the function offers the choice of including genetic principal components and other covariates.
+#' Using this function, users have freedom to experiment with various clumping and thresholding arrangements to test a wide range of
 #' various parameter values.
 #'
 #' @param DataDir
@@ -1682,9 +1685,9 @@ ComputeGeneticPC <- function(DataDir, ResultDir = tempdir(), finput, countPC = 1
 #' A character string specifying file path where all output files will be stored. The default is tempdir().
 #'
 #' @param finput
-#' Character string, specifying the prefix of the input PLINK binary files containing the genotype data i.e., the target data based on 
-#' which the clumping procedure will be performed. This file needs to be in DataDir. If the sample size of the target dataset is small  
-#' (e.g., N < 500 individuals) then users can utilize the 1000 Genomes Project samples, ensuring the use of the population that most 
+#' Character string, specifying the prefix of the input PLINK binary files containing the genotype data i.e., the target data based on
+#' which the clumping procedure will be performed. This file needs to be in DataDir. If the sample size of the target dataset is small
+#' (e.g., N < 500 individuals) then users can utilize the 1000 Genomes Project samples, ensuring the use of the population that most
 #' closely represents the target sample.
 #'
 #' @param summarystat
@@ -1701,13 +1704,13 @@ ComputeGeneticPC <- function(DataDir, ResultDir = tempdir(), finput, countPC = 1
 #' Special Notes: The first three columns needed to be `SNP`, `A1` and `BETA` or `OR`.
 #'
 #' @param phenofile
-#' A character string, specifying the name of the mandatory phenotype file. This is a plain text file with no header line; columns are: 
-#' family ID, individual ID, and phenotype.  For a binary trait, the phenotypic value should be coded as 0 or 1, then it will be recognized 
-#' as a case-control study (0 for controls and 1 for cases). The missing value should be represented by "-9" or "NA". The desired phenotype 
+#' A character string, specifying the name of the mandatory phenotype file. This is a plain text file with no header line; columns are:
+#' family ID, individual ID, and phenotype.  For a binary trait, the phenotypic value should be coded as 0 or 1, then it will be recognized
+#' as a case-control study (0 for controls and 1 for cases). The missing value should be represented by "-9" or "NA". The desired phenotype
 #' column should be labeled as "Pheno1". This file needs to be in 'DataDir'.
 #'
 #' @param covarfile
-#' A character string, specifying the name of the covariate file which is a plain .text file with no header line; columns are family ID, 
+#' A character string, specifying the name of the covariate file which is a plain .text file with no header line; columns are family ID,
 #' individual ID, and the covariates. The default is 'NULL'. This file needs to be in 'DataDir'.
 #'
 #' @param pheno_type
@@ -1720,7 +1723,7 @@ ComputeGeneticPC <- function(DataDir, ResultDir = tempdir(), finput, countPC = 1
 #' Boolean value, `TRUE` or `FALSE`, specifying whether to perform clumping or not.
 #'
 #' @param LDreference
-#' A character string, specifying the prefix of the PLINK files of the genetic similarity reference panel, (ideally the same that was used 
+#' A character string, specifying the prefix of the PLINK files of the genetic similarity reference panel, (ideally the same that was used
 #' to impute the target dataset). These files should be in 'DataDir'.
 #'
 #' @param clump_p1
@@ -1760,10 +1763,10 @@ ComputeGeneticPC <- function(DataDir, ResultDir = tempdir(), finput, countPC = 1
 #' Character string, specifying the .txt file name with known genomic regions with high LD. The default is `NULL`.
 #'
 #' @return
-#' A list object containing a dataframe, a numeric value, a GeneticPC plot (if requested), and a PGS plot. The dataframe, PGS, contains four 
-#' mandatory columns: IID (i.e., Individual ID), FID (i.e., Family ID), Pheno1 (i.e., the trait for PGS) and Score (i.e., the best PGS). Other 
-#' columns of covariates could be there. The numeric value, BestP contains the threshold of the best p-value for the best PGS model fit. Also, 
-#' the function produces several plots, including p-value thresholds vs PGS model fit and PGS distribution among male and females. For 
+#' A list object containing a dataframe, a numeric value, a GeneticPC plot (if requested), and a PGS plot. The dataframe, PGS, contains four
+#' mandatory columns: IID (i.e., Individual ID), FID (i.e., Family ID), Pheno1 (i.e., the trait for PGS) and Score (i.e., the best PGS). Other
+#' columns of covariates could be there. The numeric value, BestP contains the threshold of the best p-value for the best PGS model fit. Also,
+#' the function produces several plots, including p-value thresholds vs PGS model fit and PGS distribution among male and females. For
 #' case-control data, it also plots the PGS distribution among cases and controls, and plots ROC curves.
 #'
 #' Also, the function produces several plots such as p-value thresholds vs PGS model fit and PGS distribution among male and females.
@@ -1817,10 +1820,12 @@ ComputeGeneticPC <- function(DataDir, ResultDir = tempdir(), finput, countPC = 1
 #' ## The best threshold
 #' BestPvalue <- PGSresult$BestP$Threshold
 #' BestPvalue
-ComputePGS <- function(DataDir, ResultDir = tempdir(), finput, summarystat, phenofile, covarfile = NULL,
-    effectsize = c("BETA", "OR"), ldclump = FALSE, LDreference, clump_p1, clump_p2, clump_r2, clump_kb, byCHR = TRUE,
-    pthreshold = c(0.001, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5), highLD_regions, ld_prunning = FALSE,
-    window_size = 50, step_size = 5, r2_threshold = 0.02, nPC = 6, pheno_type = "binary") {
+ComputePGS <- function(
+      DataDir, ResultDir = tempdir(), finput, summarystat, phenofile, covarfile = NULL,
+      effectsize = c("BETA", "OR"), ldclump = FALSE, LDreference, clump_p1, clump_p2, clump_r2, clump_kb, byCHR = TRUE,
+      pthreshold = c(0.001, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5), highLD_regions, ld_prunning = FALSE,
+      window_size = 50, step_size = 5, r2_threshold = 0.02, nPC = 6, pheno_type = "binary"
+) {
     # Validate inputs
     if (!validateInputForComputePGS(DataDir, ResultDir, finput, summarystat, phenofile, covarfile, effectsize, ldclump, LDreference, clump_p1, clump_p2, clump_r2, clump_kb, byCHR, pthreshold, highLD_regions, ld_prunning, window_size, step_size, r2_threshold, nPC, pheno_type)) {
         stop("Please validate all inputs")
@@ -2119,9 +2124,8 @@ MergeRegion <- function(DataDir, ResultDir, finput1, finput2, foutput, use_commo
 #' Famfile <- NULL
 #' PVbyCHR <- FALSE
 #' plinkVCF(DataDir, ResultDir, finput, foutput, VtoP, PtoV, Famfile, PVbyCHR)
-plinkVCF <- function(
-        DataDir, ResultDir = tempdir(), finput, foutput,
-        VtoP = FALSE, PtoV = TRUE, Famfile = NULL, PVbyCHR = TRUE) {
+plinkVCF <- function(DataDir, ResultDir = tempdir(), finput, foutput,
+    VtoP = FALSE, PtoV = TRUE, Famfile = NULL, PVbyCHR = TRUE) {
     # Validate Inputs
     if (!validateInputForPlinkVCF(DataDir, ResultDir, finput, foutput, VtoP, PtoV, Famfile, PVbyCHR)) {
         return(NULL)
@@ -2303,18 +2307,17 @@ plinkVCF <- function(
 #' # Checking if there is any wrong sex assignment
 #' problematic_sex <- x[x$STATUS != "OK", ]
 SexCheck <-
-    function(
-        DataDir,
-        ResultDir = tempdir(),
-        finput,
-        infer_sex = FALSE,
-        compute_freq = FALSE,
-        LD = TRUE,
-        LD_window_size = 50,
-        LD_step_size = 5,
-        LD_r2_threshold = 0.02,
-        fmax_F = 0.2,
-        mmin_F = 0.8) {
+    function(DataDir,
+    ResultDir = tempdir(),
+    finput,
+    infer_sex = FALSE,
+    compute_freq = FALSE,
+    LD = TRUE,
+    LD_window_size = 50,
+    LD_step_size = 5,
+    LD_r2_threshold = 0.02,
+    fmax_F = 0.2,
+    mmin_F = 0.8) {
         # Validate inputs
         if (!validateInputForSexCheck(DataDir, ResultDir, finput, infer_sex, compute_freq, LD, LD_window_size, LD_step_size, LD_r2_threshold, fmax_F, mmin_F)) {
             return(NULL)
@@ -2459,7 +2462,6 @@ SexCheck <-
     }
 
 
-
 #' FilterPlinkSample: Making PLINK files with desired samples.
 #'
 #' @author Banabithi Bose
@@ -2512,13 +2514,12 @@ SexCheck <-
 #'     finput = finput, foutput = foutput, keep_remove_sample_file = keep_remove_sample_file,
 #'     keep = keep
 #' )
-FilterPlinkSample <- function(
-        DataDir, ResultDir,
-        finput,
-        foutput = NULL,
-        filter_sample = "cases",
-        keep_remove_sample_file = NULL,
-        keep = TRUE) {
+FilterPlinkSample <- function(DataDir, ResultDir,
+    finput,
+    foutput = NULL,
+    filter_sample = "cases",
+    keep_remove_sample_file = NULL,
+    keep = TRUE) {
     # Validate inputs
     if (!validateInputForFilterPlinkSample(DataDir, ResultDir, finput, foutput, filter_sample, keep_remove_sample_file, keep)) {
         return(NULL)
@@ -2640,14 +2641,13 @@ FilterPlinkSample <- function(
 #'     finput = finput, foutput = foutput, sex = sex,
 #'     xplink = FALSE, autoplink = FALSE
 #' )
-GetMFPlink <- function(
-        DataDir,
-        ResultDir = tempdir(),
-        finput,
-        foutput,
-        sex,
-        xplink = FALSE,
-        autoplink = FALSE) {
+GetMFPlink <- function(DataDir,
+    ResultDir = tempdir(),
+    finput,
+    foutput,
+    sex,
+    xplink = FALSE,
+    autoplink = FALSE) {
     if (!checkFiles(DataDir, finput)) {
         stop("Missing required Plink files in the specified DataDir.")
     }
@@ -2722,7 +2722,6 @@ GetMFPlink <- function(
         }
     )
 }
-
 
 
 #' Xhwe: Filter X-chromosome variants for HWE in females.
@@ -2896,7 +2895,6 @@ Xhwe <- function(DataDir, ResultDir = tempdir(), finput, filterSNP = TRUE, foutp
 }
 
 
-
 #' MAFdiffSexControl: Test for significantly different minor allele frequency (MAF) between sexes in control samples
 #'
 #' @author Banabithi Bose
@@ -2940,11 +2938,13 @@ Xhwe <- function(DataDir, ResultDir = tempdir(), finput, filterSNP = TRUE, foutp
 #' finput <- "GXwasR_example"
 #' foutput <- "Test_output"
 #' x <- MAFdiffSexControl(DataDir, ResultDir, finput, filterSNP = TRUE, foutput = foutput)
-MAFdiffSexControl <- function(DataDir,
-    ResultDir = tempdir(),
-    finput,
-    filterSNP = FALSE,
-    foutput = NULL) {
+MAFdiffSexControl <- function(
+      DataDir,
+      ResultDir = tempdir(),
+      finput,
+      filterSNP = FALSE,
+      foutput = NULL
+) {
     if (!validateInputForMAFdiffSexControl(DataDir, ResultDir, finput, filterSNP, foutput)) {
         return(NULL)
     }
@@ -3077,7 +3077,6 @@ MAFdiffSexControl <- function(DataDir,
 }
 
 
-
 #' QCsample: Quality control for samples in the PLINK binary files.
 #'
 #' @author Banabithi Bose
@@ -3178,22 +3177,24 @@ MAFdiffSexControl <- function(DataDir,
 #'     foutput = foutput, imiss = imiss, het = het, IBD = IBD,
 #'     ambi_out = ambi_out
 #' )
-QCsample <- function(DataDir,
-    ResultDir,
-    finput,
-    foutput = NULL,
-    imiss,
-    het,
-    small_sample_mod = FALSE,
-    IBD,
-    IBDmatrix = FALSE,
-    ambi_out = TRUE,
-    legend_text_size = 8,
-    legend_title_size = 7,
-    axis_text_size = 5,
-    axis_title_size = 7,
-    title_size = 9,
-    filterSample = TRUE) {
+QCsample <- function(
+      DataDir,
+      ResultDir,
+      finput,
+      foutput = NULL,
+      imiss,
+      het,
+      small_sample_mod = FALSE,
+      IBD,
+      IBDmatrix = FALSE,
+      ambi_out = TRUE,
+      legend_text_size = 8,
+      legend_title_size = 7,
+      axis_text_size = 5,
+      axis_title_size = 7,
+      title_size = 9,
+      filterSample = TRUE
+) {
     # Validate parameters
     validateInputForQCsample(DataDir, ResultDir, finput, foutput, imiss, het, small_sample_mod, IBD, IBDmatrix, ambi_out, legend_text_size, legend_title_size, axis_text_size, axis_title_size, title_size, filterSample = TRUE)
 
@@ -3396,8 +3397,6 @@ QCsample <- function(DataDir,
         }
     )
 }
-
-
 
 
 #' Miami plot
@@ -3692,13 +3691,12 @@ GXWASmiami <- function(ResultDir = tempdir(), FemaleWAS, MaleWAS, snp_pval = 1e-
 #'     snp_pval = snp_pval, plot.jpeg = TRUE, suggestiveline = 5, genomewideline = 7.3,
 #'     MF.mc.cores = 1, ncores = ncores
 #' )
-GXwas <- function(
-        DataDir, ResultDir, finput, trait = c("binary", "quantitative"), standard_beta = TRUE,
-        xmodel = c("FMcombx01", "FMcombx02", "FMstratified", "GWAScxci"), sex = FALSE, xsex = FALSE,
-        covarfile = NULL, interaction = FALSE, covartest = c("ALL"), Inphenocov = c("ALL"), combtest = c("fisher.method", "fisher.method.perm", "stouffer.method"),
-        MF.zero.sub = 0.00001, B = 10000, MF.mc.cores = 1, MF.na.rm = FALSE,
-        MF.p.corr = "none", plot.jpeg = FALSE, plotname = "GXwas.plot", snp_pval = 1e-08,
-        annotateTopSnp = FALSE, suggestiveline = 5, genomewideline = 7.3, ncores = 0) {
+GXwas <- function(DataDir, ResultDir, finput, trait = c("binary", "quantitative"), standard_beta = TRUE,
+    xmodel = c("FMcombx01", "FMcombx02", "FMstratified", "GWAScxci"), sex = FALSE, xsex = FALSE,
+    covarfile = NULL, interaction = FALSE, covartest = c("ALL"), Inphenocov = c("ALL"), combtest = c("fisher.method", "fisher.method.perm", "stouffer.method"),
+    MF.zero.sub = 0.00001, B = 10000, MF.mc.cores = 1, MF.na.rm = FALSE,
+    MF.p.corr = "none", plot.jpeg = FALSE, plotname = "GXwas.plot", snp_pval = 1e-08,
+    annotateTopSnp = FALSE, suggestiveline = 5, genomewideline = 7.3, ncores = 0) {
     # Initialize progress bar
 
     pb <- progress::progress_bar$new(
@@ -3932,13 +3930,12 @@ GXwas <- function(
 #'     plotname = "Meta_Analysis.plot", pval_filter, top_snp_pval, max_top_snps,
 #'     chosen_snps_file = NULL, byCHR, pval_threshold_manplot
 #' )
-MetaGWAS <- function(
-        DataDir, SummData = c(""), ResultDir = tempdir(), SNPfile = NULL,
-        useSNPposition = TRUE,
-        UseA1 = FALSE, GCse = TRUE,
-        plotname = "Meta_Analysis.plot", pval_filter = "R",
-        top_snp_pval = 1e-08, max_top_snps = 6, chosen_snps_file = NULL,
-        byCHR = FALSE, pval_threshold_manplot = 1e-05) {
+MetaGWAS <- function(DataDir, SummData = c(""), ResultDir = tempdir(), SNPfile = NULL,
+    useSNPposition = TRUE,
+    UseA1 = FALSE, GCse = TRUE,
+    plotname = "Meta_Analysis.plot", pval_filter = "R",
+    top_snp_pval = 1e-08, max_top_snps = 6, chosen_snps_file = NULL,
+    byCHR = FALSE, pval_threshold_manplot = 1e-05) {
     # Validate input parameters
     validateInputForMetaGWAS(DataDir, ResultDir, SummData, SNPfile, useSNPposition, UseA1, GCse, plotname, pval_filter, top_snp_pval, max_top_snps, chosen_snps_file, byCHR, pval_threshold_manplot)
 
@@ -4026,7 +4023,6 @@ MetaGWAS <- function(
             # Filter and prepare SNPs for forest plots
             top_snp_pval <- adjustPvalThreshold(top_snp_pval, MR, pval_filter)
             MRfiltered <- filterSNPsForForestPlot(MR, top_snp_pval, pval_filter)
-
 
 
             # Update MRfiltered if a specific SNP file is provided
@@ -4136,7 +4132,6 @@ MetaGWAS <- function(
 }
 
 
-
 #' ClumpLD: Clumping SNPs using linkage disequilibrium between SNPs
 #'
 #' @description
@@ -4229,10 +4224,9 @@ MetaGWAS <- function(
 #'     DataDir, finput, SNPdata, ResultDir, clump_p1,
 #'     clump_p2, clump_r2, clump_kb, byCHR
 #' )
-ClumpLD <- function(
-        DataDir, finput, SNPdata, ResultDir = tempdir(),
-        clump_p1, clump_p2, clump_r2, clump_kb, byCHR = TRUE,
-        clump_best = TRUE, clump_index_first = TRUE) {
+ClumpLD <- function(DataDir, finput, SNPdata, ResultDir = tempdir(),
+    clump_p1, clump_p2, clump_r2, clump_kb, byCHR = TRUE,
+    clump_best = TRUE, clump_index_first = TRUE) {
     # Check for an unsupported combination:
     if (clump_best == TRUE && clump_index_first == FALSE) {
         warning("The combination clump_best = TRUE and clump_index_first = FALSE is not recommended. Enforcing clump_index_first = TRUE.")
@@ -4559,7 +4553,6 @@ SexDiffZscore <- function(inputdata) {
 }
 
 
-
 #' GeneticCorrBT: Computing genetic correlation between two traits.
 #'
 #' @description
@@ -4691,12 +4684,14 @@ SexDiffZscore <- function(inputdata) {
 #'     partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3,
 #'     cripticut = 0.025, minMAF = NULL, maxMAF = NULL, excludeResidual = TRUE, ncores = ncores
 #' )
-GeneticCorrBT <- function(DataDir, ResultDir, finput, byCHR = FALSE,
-    REMLalgo = c(0, 1, 2), nitr = 100, phenofile, cat_covarfile = NULL, quant_covarfile = NULL,
-    computeGRM = TRUE, grmfile_name = NULL,
-    partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3,
-    cripticut = 0.025, minMAF = NULL, maxMAF = NULL,
-    excludeResidual = FALSE, ncores = 2) {
+GeneticCorrBT <- function(
+      DataDir, ResultDir, finput, byCHR = FALSE,
+      REMLalgo = c(0, 1, 2), nitr = 100, phenofile, cat_covarfile = NULL, quant_covarfile = NULL,
+      computeGRM = TRUE, grmfile_name = NULL,
+      partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3,
+      cripticut = 0.025, minMAF = NULL, maxMAF = NULL,
+      excludeResidual = FALSE, ncores = 2
+) {
     # Validate input parameters
     validateInputForGeneticCorrBT(
         DataDir, ResultDir, finput, byCHR, REMLalgo, nitr, phenofile,
@@ -4864,7 +4859,6 @@ GeneticCorrBT <- function(DataDir, ResultDir, finput, byCHR = FALSE,
 }
 
 
-
 #' SexRegress: Performing linear regression analysis with quantitative response variable.
 #'
 #' @description
@@ -5006,19 +5000,21 @@ SexRegress <- function(fdata, regressor_index, response_index) {
 #'     regionfile = FALSE, filterCHR = NULL, Hg = "38", exclude = TRUE
 #' )
 FilterRegion <-
-    function(DataDir,
-    ResultDir,
-    finput,
-    foutput,
-    CHRX = TRUE,
-    CHRY = FALSE,
-    filterPAR = TRUE,
-    filterXTR = TRUE,
-    filterAmpliconic = TRUE,
-    regionfile = FALSE,
-    filterCHR = NULL,
-    Hg = "19",
-    exclude = TRUE) {
+    function(
+      DataDir,
+      ResultDir,
+      finput,
+      foutput,
+      CHRX = TRUE,
+      CHRY = FALSE,
+      filterPAR = TRUE,
+      filterXTR = TRUE,
+      filterAmpliconic = TRUE,
+      regionfile = FALSE,
+      filterCHR = NULL,
+      Hg = "19",
+      exclude = TRUE
+    ) {
         # Validate parameters
         validateFilterRegionParams(DataDir, ResultDir, finput, foutput, CHRX, CHRY, filterPAR, filterXTR, filterAmpliconic, regionfile, filterCHR, Hg, exclude)
 
@@ -5156,7 +5152,6 @@ FilterRegion <-
             }
         )
     }
-
 
 
 # Updated in 5.0
@@ -5441,22 +5436,21 @@ FilterAllele <- function(DataDir, ResultDir, finput, foutput) {
 #'     suggestiveline = 3, genomewideline = 5.69897, ncores = 1
 #' )
 #'
-PvalComb <- function(
-        SumstatMale, SumstatFemale,
-        combtest,
-        MF.p.corr = "none",
-        MF.zero.sub = 0.00001,
-        MF.na.rm = TRUE,
-        MF.mc.cores = 1,
-        B = 1000,
-        plot.jpeg = TRUE,
-        plotname = "GXwas.plot",
-        PlotDir = tempdir(),
-        snp_pval,
-        annotateTopSnp = FALSE,
-        suggestiveline = 5,
-        genomewideline = 7.3,
-        ncores = 0) {
+PvalComb <- function(SumstatMale, SumstatFemale,
+    combtest,
+    MF.p.corr = "none",
+    MF.zero.sub = 0.00001,
+    MF.na.rm = TRUE,
+    MF.mc.cores = 1,
+    B = 1000,
+    plot.jpeg = TRUE,
+    plotname = "GXwas.plot",
+    PlotDir = tempdir(),
+    snp_pval,
+    annotateTopSnp = FALSE,
+    suggestiveline = 5,
+    genomewideline = 7.3,
+    ncores = 0) {
     # Validate inputs
     validation_result <- validatePvalCombInputs(SumstatMale, SumstatFemale, combtest, MF.p.corr, MF.zero.sub, MF.na.rm, MF.mc.cores, B, plot.jpeg, plotname, snp_pval, annotateTopSnp, suggestiveline, genomewideline, ncores)
     if (!is.null(validation_result)) {
@@ -5556,7 +5550,6 @@ PvalComb <- function(
         }
     )
 }
-
 
 
 #' FilterSNP: Filter out SNPs.
@@ -6009,7 +6002,7 @@ LDPrune <- function(DataDir, finput, ResultDir = tempdir(), window_size = 50, st
 #' The number of cores to be used. The default is 2.
 #'
 #' @details
-#' This function requires access to the \href{https://zenodo.org/records/16923484}{reference LD data} via an 
+#' This function requires access to the \href{https://zenodo.org/records/16923484}{reference LD data} via an
 #' environment variable. You must set one of the following environment variables to the appropriate directory:
 #'
 #' - `UKB_ARRAY_PATH` for the Axiom Array reference (`UKB_array_SVD_eigen90_extraction`)
@@ -6044,16 +6037,18 @@ LDPrune <- function(DataDir, finput, ResultDir = tempdir(), window_size = 50, st
 #'         parallel = TRUE
 #'     )
 #' }
-SumstatGenCorr <- function(ResultDir = tempdir(),
-    referenceLD,
-    sumstat1,
-    sumstat2,
-    Nref = 335265,
-    N0 = min(sumstat1$N),
-    eigen.cut = "automatic",
-    lim = exp(-18),
-    parallel = FALSE,
-    numCores = 2) {
+SumstatGenCorr <- function(
+      ResultDir = tempdir(),
+      referenceLD,
+      sumstat1,
+      sumstat2,
+      Nref = 335265,
+      N0 = min(sumstat1$N),
+      eigen.cut = "automatic",
+      lim = exp(-18),
+      parallel = FALSE,
+      numCores = 2
+) {
     reference_paths <- list(
         UKB_imputed_hapmap2_SVD_eigen99_extraction = Sys.getenv("UKB_IMPUTED_HAPMAP2_PATH", unset = NA),
         UKB_imputed_SVD_eigen99_extraction = Sys.getenv("UKB_IMPUTED_PATH", unset = NA),

--- a/R/GXwasR_main_functions.R
+++ b/R/GXwasR_main_functions.R
@@ -1196,7 +1196,7 @@ QCsnp <-
 #' * `P` (i.e., p-values)
 #' * `n_eff` (i.e., effective sample size)
 #'
-#' For case-control study, effective sample size should be \eqn{4 / (1/<# of cases> + 1/<# of controls>)}. The default is `NULL`.
+#' For case-control study, effective sample size should be \eqn{4 / (1/<qty of cases> + 1/<qty of controls>)}. The default is `NULL`.
 #'
 #' @param ncores
 #' Integer value, specifying the number of cores to be used for running LDSC model. The default is 2.
@@ -3810,7 +3810,7 @@ GXwas <- function(
 #' (i.e., SNP identifier), ‘BETA’ (i.e., effect-size or logarithm of odds ratio), ‘SE’ (i.e., standard error of BETA),
 #' ‘P’ (i.e., p-values), 'NMISS' (i.e., effective sample size), 'L95' (i.e., lower limit of 95% confidence interval) and
 #' 'U95' (i.e., upper limit of 95% confidence interval) are in mandatory column headers. These files needed to be in DataDir.
-#' If the numbers of cases and controls are unequal, effective sample size should be \eqn{4 / (1/<# of cases> + 1/<# of controls>)}.
+#' If the numbers of cases and controls are unequal, effective sample size should be \eqn{4 / (1/<qty of cases> + 1/<qty of controls>)}.
 #' A smaller "effective" sample size may be used for samples that include related individuals, however simulations indicate
 #' that small changes in the effective sample size have relatively little effect on the final p-value
 #' \insertCite{Willer2010}{GXwasR}. Columns, such as, `CHR` (Chromosome code), `BP` (Basepair position), `A1` (First allele code),

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,7 +1,7 @@
 bibentry(
   bibtype  = "Article",
   title    = "GXwasR: A Toolkit for Investigating Sex-Differentiated Genetic Effects on Complex Traits",
-  author   = "Banabithi Bose, Freida Blostein, Jeewoo Kim, Jessica Winters, Ky’Era V. Actkins, David Mayer, Harrsha Congivaram, Maria Niarchou, Digna Velez Edwards, Lea K. Davis, Barbara E. Stranger",
+  author   = "Banabithi Bose, Freida Blostein, Jeewoo Kim, Jessica Winters, Ky'Era V. Actkins, David Mayer, Harrsha Congivaram, Maria Niarchou, Digna Velez Edwards, Lea K. Davis, Barbara E. Stranger",
   journal  = "medRxiv 2025.06.10.25329327",
   year     = "2025",
   volume   = "",

--- a/man/DiffZeroOne.Rd
+++ b/man/DiffZeroOne.Rd
@@ -30,7 +30,7 @@ A dataframe with columns:
 }
 \description{
 This function tests the null hypothesis that a measured statistics (example: genetic correlation,
-rg for a trait) < 1 using a 1-tailed test compared with a normal distribution (z = (1 − measure statistics)/Standard error).
+rg for a trait) < 1 using a 1-tailed test compared with a normal distribution (z = (1 - measure statistics)/Standard error).
 For multiple tests, users are encouraged to apply a Bonferroni multiple-testing correction.
 }
 \examples{

--- a/man/EstimateHerit.Rd
+++ b/man/EstimateHerit.Rd
@@ -68,7 +68,7 @@ to provide \code{precomputedLD} argument. See below.}
 \item \code{n_eff} (i.e., effective sample size)
 }
 
-For case-control study, effective sample size should be \eqn{4 / (1/<# of cases> + 1/<# of controls>)}. The default is \code{NULL}.}
+For case-control study, effective sample size should be \eqn{4 / (1/<qty of cases> + 1/<qty of controls>)}. The default is \code{NULL}.}
 
 \item{ncores}{Integer value, specifying the number of cores to be used for running LDSC model. The default is 2.}
 

--- a/man/GXwas.Rd
+++ b/man/GXwas.Rd
@@ -107,17 +107,17 @@ Note: This feature is not valid for the XCGA model for the XWAS part.}
 
 \item{combtest}{Character vector specifying method for combining p-values after stratified GWAS/XWAS models.
 Choices are “stouffer.method”, "fisher.method" and "fisher.method.perm". For fisher.method the function for combining
-p-values uses a statistic, \eqn{S = -2 ∑^k /log p}, which follows a \eqn{χ^2} distribution with 2k degrees of freedom \insertCite{Fisher1925}{GXwasR}.
+p-values uses a statistic, \eqn{S = -2 \sum_{i=1}^{k} \log(p_i)}, which follows a \eqn{\chi^2} distribution with 2k degrees of freedom \insertCite{Fisher1925}{GXwasR}.
 
-For fisher.method.perm, using p-values from stratified tests, the summary statistic for combining p-values is \eqn{S = -2 ∑ /log p}.
+For fisher.method.perm, using p-values from stratified tests, the summary statistic for combining p-values is \eqn{S = -2 \sum_{i=1}^{k} \log(p_i)}.
 A p-value for this statistic can be derived by randomly generating summary statistics \insertCite{Rhodes2002}{GXwasR}. Therefore, a p-value is randomly
 sampled from each contributing study, and a random statistic is calculated. The fraction of random statistics greater or
 equal to S then gives the final p-value.
 
 For stouffer.method ,the function applies Stouffer’s method \insertCite{Stouffer1949}{GXwasR} to the p-values assuming that the p-values to be combined are
 independent. Letting p1, p2, . . . , pk denote the individual (one- or two-sided) p-values of the k hypothesis tests to be
-combined, the test statistic is then computed with \eqn{$z = ∑^k_{1}frac{z_{i}}{sqrt(k)}$} where \eqn{$z_{i}$ = Φ−1 (1 – $p_{i}$)} and
-\eqn{Φ −1 (·)} denotes the inverse of the cumulative distribution function of a standard normal distribution. Under the joint null
+combined, the test statistic is then computed as \eqn{z = \frac{\sum_{i=1}^{k} z_i}{\sqrt{k}}}, where \eqn{z_i = \Phi^{-1}(1 - p_i)} and
+\eqn{\Phi^{-1}(\cdot)} denotes the inverse of the cumulative distribution function of a standard normal distribution. Under the joint null
 hypothesis, the test statistic follows a standard normal distribution which is used to compute the combined p-value. This
 functionality is taken from the R package poolr \insertCite{Cinar2022}{GXwasR}.
 

--- a/man/MetaGWAS.Rd
+++ b/man/MetaGWAS.Rd
@@ -28,7 +28,7 @@ MetaGWAS(
 (i.e., SNP identifier), ‘BETA’ (i.e., effect-size or logarithm of odds ratio), ‘SE’ (i.e., standard error of BETA),
 ‘P’ (i.e., p-values), 'NMISS' (i.e., effective sample size), 'L95' (i.e., lower limit of 95\% confidence interval) and
 'U95' (i.e., upper limit of 95\% confidence interval) are in mandatory column headers. These files needed to be in DataDir.
-If the numbers of cases and controls are unequal, effective sample size should be \eqn{4 / (1/<# of cases> + 1/<# of controls>)}.
+If the numbers of cases and controls are unequal, effective sample size should be \eqn{4 / (1/<qty of cases> + 1/<qty of controls>)}.
 A smaller "effective" sample size may be used for samples that include related individuals, however simulations indicate
 that small changes in the effective sample size have relatively little effect on the final p-value
 \insertCite{Willer2010}{GXwasR}. Columns, such as, \code{CHR} (Chromosome code), \code{BP} (Basepair position), \code{A1} (First allele code),

--- a/man/PvalComb.Rd
+++ b/man/PvalComb.Rd
@@ -47,10 +47,10 @@ Other columns may present.}
 Other columns may present.}
 
 \item{combtest}{Character vector specifying method for combining p-values for stratified GWAS models. Choices are “stouffer.method”,
-"fisher.method" and "fisher.method.perm". For fisher.method the function for combining p-values uses a statistic,
-\eqn{S = -2 ∑^k /log p}, which follows a \eqn{χ^2} distribution with 2k degrees of freedom \insertCite{Fisher1925}{GXwasR}.
+"fisher.method" and "fisher.method.perm". For fisher.method, the function for combining p-values uses a statistic,
+\eqn{S = -2 \sum_{i=1}^{k} \log(p_i)}, which follows a \eqn{\chi^2} distribution with 2k degrees of freedom \insertCite{Fisher1925}{GXwasR}.
 For fisher.method.perm, using p-values from stratified tests, the summary statistic for combining p-values
-is \eqn{S = -2 ∑ /log p}. A p-value for this statistic can be derived by randomly generating summary statistics \insertCite{Rhodes2002}{GXwasR}.
+is \eqn{S = -2 \sum_{i=1}^{k} \log(p_i)}. A p-value for this statistic can be derived by randomly generating summary statistics \insertCite{Rhodes2002}{GXwasR}.
 Therefore, a p-value is randomly sampled from each contributing study, and a random statistic is calculated. The
 fraction of random statistics greater or equal to S then gives the final p-value.}
 

--- a/man/SexDiffZscore.Rd
+++ b/man/SexDiffZscore.Rd
@@ -27,12 +27,12 @@ columns added.
 }
 \description{
 This function calculates the difference in any kind of measured entities,(example: including SNP heritability estimate,
-genetic correlation, and GWAS β values) between sexes using a Z-score and its associated p-value statistic.
+genetic correlation, and GWAS \eqn{\beta} values) between sexes using a Z-score and its associated p-value statistic.
 When STAT/SE is normally distributed and the test statistics are independent in sex, the test is well calibrated. If
 the statistics are positively correlated, this test is conservative (1).
 
 We could define SNPs with SDEs as those variants at the extreme ends of the distribution with an absolute value of the
-Z-score greater than 3(|Z-score| > 3), which is roughly equivalent to p <10−3, and represents 0.3\% of all tested SNPs.
+Z-score greater than 3(|Z-score| > 3), which is roughly equivalent to p <10-3, and represents 0.3\% of all tested SNPs.
 The input dataframes should only include X-chromosome in order to obtain results for sex differences based solely on
 X-linked loci.
 }

--- a/man/TestXGene.Rd
+++ b/man/TestXGene.Rd
@@ -173,7 +173,7 @@ Phase 3 reference genotype data. Users also have options to define the regional 
 to their investigation.
 
 This function computes gene-wise SNP-SNP correlation matrices and can perform nine different gene-based tests, such as, “BT" (burden test),
-"SKAT" (sequence kernel association test), "SKATO" (combination of BT and SKAT), "sumchi" (sum of χ2-statistics), "ACAT" (aggregated
+"SKAT" (sequence kernel association test), "SKATO" (combination of BT and SKAT), "sumchi" (sum of \eqn{\chi^2}-statistics), "ACAT" (aggregated
 Cauchy association test for combining P values), "PCA"(principal component approach), "FLM"( functional multiple linear regression model),
 "simpleM" (Bonferroni correction test), "minp" (minimum P-value) leveraging PLINK1.9 \insertCite{Purcell2007}{GXwasR} and sumFREGAT
 \insertCite{Svishcheva2019,Belonogova2022}{GXwasR} tools.

--- a/tests/testthat/test-MetaGWAS.R
+++ b/tests/testthat/test-MetaGWAS.R
@@ -22,7 +22,7 @@ test_that("MetaGWAS produces the correct output", {
         SNPfile = NULL, useSNPposition = TRUE, UseA1 = UseA1, GCse = GCse,
         plotname = "Meta_Analysis.plot", pval_filter, top_snp_pval, max_top_snps,
         chosen_snps_file = NULL, byCHR, pval_threshold_manplot
-        )
+    )
     expect_type(x, "list")
     expect_equal(length(x), 6)
     expect_equal(x$Resultfixed %>% head(), data.frame(

--- a/vignettes/GXwasR_heritability.Rmd
+++ b/vignettes/GXwasR_heritability.Rmd
@@ -67,37 +67,37 @@ help(EstimateHerit, package = GXwasR)
 # Running
 data("highLD_hg19", package = "GXwasR")
 DataDir <- GXwasR:::GXwasR_data()
-ResultDir = tempdir()
+ResultDir <- tempdir()
 finput <- "GXwasR_example"
-ncores = 3
-model = "GREML"
-byCHR = FALSE
-r2_LD = 0
-LDSC_blocks = 20
-REMLalgo = 0
-nitr = 100
-cat_covarfile = NULL
-quant_covarfile = NULL
-prevalence = 0.01
-partGRM = FALSE
-autosome = TRUE
-Xsome = TRUE
-nGRM = 3
-cripticut = 0.025
-minMAF = NULL
-maxMAF = NULL
-hg = "hg19"
-byCHR = TRUE
-PlotIndepSNP = TRUE
-IndepSNP_window_size = 50
-IndepSNP_step_size = 5
-IndepSNP_r2_threshold = 0.02
+ncores <- 3
+model <- "GREML"
+byCHR <- FALSE
+r2_LD <- 0
+LDSC_blocks <- 20
+REMLalgo <- 0
+nitr <- 100
+cat_covarfile <- NULL
+quant_covarfile <- NULL
+prevalence <- 0.01
+partGRM <- FALSE
+autosome <- TRUE
+Xsome <- TRUE
+nGRM <- 3
+cripticut <- 0.025
+minMAF <- NULL
+maxMAF <- NULL
+hg <- "hg19"
+byCHR <- TRUE
+PlotIndepSNP <- TRUE
+IndepSNP_window_size <- 50
+IndepSNP_step_size <- 5
+IndepSNP_r2_threshold <- 0.02
 
 # For saving the plot in .jpeg file, make plotjpeg = TRUE.
 
-H2 <- EstimateHerit(DataDir = DataDir, ResultDir = ResultDir, finput = finput, summarystat = NULL, ncores = 5, model = model, byCHR = TRUE, r2_LD = 0, LDSC_blocks = 20,REMLalgo = 0, nitr = nitr, cat_covarfile = NULL, quant_covarfile = NULL,prevalence = 0.01, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3, computeGRM = TRUE, grmfile_name = NULL, cripticut = 0.025, minMAF = NULL, maxMAF = NULL,hg = "hg19",PlotIndepSNP = TRUE, IndepSNP_window_size = 50,IndepSNP_step_size = 5,IndepSNP_r2_threshold = 0.02,highLD_regions = highLD_hg19, plotjpeg = TRUE, plotname = "Heritability_Plots")
+H2 <- EstimateHerit(DataDir = DataDir, ResultDir = ResultDir, finput = finput, summarystat = NULL, ncores = 5, model = model, byCHR = TRUE, r2_LD = 0, LDSC_blocks = 20, REMLalgo = 0, nitr = nitr, cat_covarfile = NULL, quant_covarfile = NULL, prevalence = 0.01, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3, computeGRM = TRUE, grmfile_name = NULL, cripticut = 0.025, minMAF = NULL, maxMAF = NULL, hg = "hg19", PlotIndepSNP = TRUE, IndepSNP_window_size = 50, IndepSNP_step_size = 5, IndepSNP_r2_threshold = 0.02, highLD_regions = highLD_hg19, plotjpeg = TRUE, plotname = "Heritability_Plots")
 
-#Heritability
+# Heritability
 H2
 ```
 
@@ -110,10 +110,9 @@ Set:
 
 
 ```{r}
+H2 <- EstimateHerit(DataDir = DataDir, ResultDir = ResultDir, finput = finput, summarystat = NULL, ncores = 5, model = model, byCHR = TRUE, r2_LD = 0, LDSC_blocks = 20, REMLalgo = 0, nitr = nitr, cat_covarfile = NULL, quant_covarfile = NULL, prevalence = 0.01, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3, computeGRM = FALSE, grmfile_name = "GXwasR", cripticut = 0.025, minMAF = NULL, maxMAF = NULL, hg = "hg19", PlotIndepSNP = TRUE, IndepSNP_window_size = 50, IndepSNP_step_size = 5, IndepSNP_r2_threshold = 0.02, highLD_regions = highLD_hg19, plotjpeg = FALSE, plotname = "Heritability_Plots")
 
-H2 <- EstimateHerit(DataDir = DataDir, ResultDir = ResultDir, finput = finput, summarystat = NULL, ncores = 5, model = model, byCHR = TRUE, r2_LD = 0, LDSC_blocks = 20,REMLalgo = 0, nitr = nitr, cat_covarfile = NULL, quant_covarfile = NULL,prevalence = 0.01, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3, computeGRM = FALSE, grmfile_name = "GXwasR", cripticut = 0.025, minMAF = NULL, maxMAF = NULL,hg = "hg19",PlotIndepSNP = TRUE, IndepSNP_window_size = 50,IndepSNP_step_size = 5,IndepSNP_r2_threshold = 0.02,highLD_regions = highLD_hg19, plotjpeg = FALSE, plotname = "Heritability_Plots")
-
-#Heritability
+# Heritability
 H2
 ```
 
@@ -129,10 +128,9 @@ grmfile_name = NULL.......if computeGRM = TRUE the grmfile_name is by default NU
 In genome-wide case, there no plot will be generated.
 
 ```{r}
+H2 <- EstimateHerit(DataDir = DataDir, ResultDir = ResultDir, finput = finput, summarystat = NULL, ncores = 5, model = model, byCHR = FALSE, r2_LD = 0, LDSC_blocks = 20, REMLalgo = 0, nitr = nitr, cat_covarfile = NULL, quant_covarfile = NULL, prevalence = 0.01, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3, computeGRM = TRUE, grmfile_name = NULL, cripticut = 0.025, minMAF = NULL, maxMAF = NULL, hg = "hg19", PlotIndepSNP = TRUE, IndepSNP_window_size = 50, IndepSNP_step_size = 5, IndepSNP_r2_threshold = 0.02, highLD_regions = highLD_hg19, plotjpeg = FALSE, plotname = "Heritability_Plots")
 
-H2 <- EstimateHerit(DataDir = DataDir, ResultDir = ResultDir, finput = finput, summarystat = NULL, ncores = 5, model = model, byCHR = FALSE, r2_LD = 0, LDSC_blocks = 20,REMLalgo = 0, nitr = nitr, cat_covarfile = NULL, quant_covarfile = NULL,prevalence = 0.01, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3, computeGRM = TRUE, grmfile_name = NULL, cripticut = 0.025, minMAF = NULL, maxMAF = NULL,hg = "hg19",PlotIndepSNP = TRUE, IndepSNP_window_size = 50,IndepSNP_step_size = 5,IndepSNP_r2_threshold = 0.02,highLD_regions = highLD_hg19, plotjpeg = FALSE, plotname = "Heritability_Plots")
-
-#Heritability
+# Heritability
 H2
 ```
 
@@ -148,10 +146,9 @@ grmfile_name = "GXwasR"
 In genome-wide case, there no plot will be generated.
 
 ```{r}
+H2 <- EstimateHerit(DataDir = DataDir, ResultDir = ResultDir, finput = finput, summarystat = NULL, ncores = 5, model = model, byCHR = FALSE, r2_LD = 0, LDSC_blocks = 20, REMLalgo = 0, nitr = nitr, cat_covarfile = NULL, quant_covarfile = NULL, prevalence = 0.01, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3, computeGRM = FALSE, grmfile_name = "GXwasR", cripticut = 0.025, minMAF = NULL, maxMAF = NULL, hg = "hg19", PlotIndepSNP = TRUE, IndepSNP_window_size = 50, IndepSNP_step_size = 5, IndepSNP_r2_threshold = 0.02, highLD_regions = highLD_hg19, plotjpeg = FALSE, plotname = "Heritability_Plots")
 
-H2 <- EstimateHerit(DataDir = DataDir, ResultDir = ResultDir, finput = finput, summarystat = NULL, ncores = 5, model = model, byCHR = FALSE, r2_LD = 0, LDSC_blocks = 20,REMLalgo = 0, nitr = nitr, cat_covarfile = NULL, quant_covarfile = NULL,prevalence = 0.01, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3, computeGRM = FALSE, grmfile_name = "GXwasR", cripticut = 0.025, minMAF = NULL, maxMAF = NULL,hg = "hg19",PlotIndepSNP = TRUE, IndepSNP_window_size = 50,IndepSNP_step_size = 5,IndepSNP_r2_threshold = 0.02,highLD_regions = highLD_hg19, plotjpeg = FALSE, plotname = "Heritability_Plots")
-
-#Heritability
+# Heritability
 H2
 ```
 
@@ -161,15 +158,15 @@ data("Summary_Stat_Ex1", package = "GXwasR")
 model <- "LDSC"
 data("GXwasRData")
 DataDir <- GXwasR:::GXwasR_data()
-ResultDir = tempdir()
+ResultDir <- tempdir()
 finput <- "GXwasR_example"
-test.sumstats <- na.omit(Summary_Stat_Ex1[Summary_Stat_Ex1$TEST=="ADD",c(1:4,6:8)])
-colnames(test.sumstats) <- c("chr","rsid","pos","a1","n_eff","beta","beta_se")
-summarystat = test.sumstats
-highLD_regions = highLD_hg19
+test.sumstats <- na.omit(Summary_Stat_Ex1[Summary_Stat_Ex1$TEST == "ADD", c(1:4, 6:8)])
+colnames(test.sumstats) <- c("chr", "rsid", "pos", "a1", "n_eff", "beta", "beta_se")
+summarystat <- test.sumstats
+highLD_regions <- highLD_hg19
 
-H2 <- EstimateHerit(DataDir = DataDir, ResultDir = ResultDir, finput = "GXwasR_example", summarystat = summarystat, ncores, model = model, byCHR = FALSE, r2_LD = 0, LDSC_blocks = 20,REMLalgo = 0, nitr = 100, cat_covarfile = NULL, quant_covarfile = NULL,prevalence = 0.01, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3,cripticut = 0.025, minMAF = NULL, maxMAF = NULL,hg = "hg19",PlotIndepSNP = TRUE, IndepSNP_window_size = 50,IndepSNP_step_size = 5,IndepSNP_r2_threshold = 0.02,highLD_regions = highLD_hg19)
-#Heritability
+H2 <- EstimateHerit(DataDir = DataDir, ResultDir = ResultDir, finput = "GXwasR_example", summarystat = summarystat, ncores, model = model, byCHR = FALSE, r2_LD = 0, LDSC_blocks = 20, REMLalgo = 0, nitr = 100, cat_covarfile = NULL, quant_covarfile = NULL, prevalence = 0.01, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3, cripticut = 0.025, minMAF = NULL, maxMAF = NULL, hg = "hg19", PlotIndepSNP = TRUE, IndepSNP_window_size = 50, IndepSNP_step_size = 5, IndepSNP_r2_threshold = 0.02, highLD_regions = highLD_hg19)
+# Heritability
 H2
 ```
 
@@ -177,14 +174,14 @@ H2
 ```{r}
 model <- "LDSC"
 DataDir <- GXwasR:::GXwasR_data()
-ResultDir = tempdir()
+ResultDir <- tempdir()
 finput <- "GXwasR_example"
-test.sumstats <- na.omit(Summary_Stat_Ex1[Summary_Stat_Ex1$TEST=="ADD",c(1:4,6:8)])
-colnames(test.sumstats) <- c("chr","rsid","pos","a1","n_eff","beta","beta_se")
-summarystat = test.sumstats
-highLD_regions = highLD_hg19
+test.sumstats <- na.omit(Summary_Stat_Ex1[Summary_Stat_Ex1$TEST == "ADD", c(1:4, 6:8)])
+colnames(test.sumstats) <- c("chr", "rsid", "pos", "a1", "n_eff", "beta", "beta_se")
+summarystat <- test.sumstats
+highLD_regions <- highLD_hg19
 
-H2 <- EstimateHerit(DataDir = DataDir, ResultDir = ResultDir, finput = "GXwasR_example", summarystat = summarystat, ncores, model = model, byCHR = TRUE, r2_LD = 0, LDSC_blocks = 20,REMLalgo = 0, nitr = 100, cat_covarfile = NULL, quant_covarfile = NULL,prevalence = 0.01, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3,cripticut = 0.025, minMAF = NULL, maxMAF = NULL,hg = "hg19",PlotIndepSNP = TRUE, IndepSNP_window_size = 50,IndepSNP_step_size = 5,IndepSNP_r2_threshold = 0.02,highLD_regions = highLD_hg19)
+H2 <- EstimateHerit(DataDir = DataDir, ResultDir = ResultDir, finput = "GXwasR_example", summarystat = summarystat, ncores, model = model, byCHR = TRUE, r2_LD = 0, LDSC_blocks = 20, REMLalgo = 0, nitr = 100, cat_covarfile = NULL, quant_covarfile = NULL, prevalence = 0.01, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3, cripticut = 0.025, minMAF = NULL, maxMAF = NULL, hg = "hg19", PlotIndepSNP = TRUE, IndepSNP_window_size = 50, IndepSNP_step_size = 5, IndepSNP_r2_threshold = 0.02, highLD_regions = highLD_hg19)
 
 # Chromosome-wise Heritability Estimate
 H2
@@ -196,64 +193,70 @@ help(GeneticCorrBT, package = GXwasR)
 ```
 ## <a id = "Running GeneticCorrBT()"> </a> Running GeneticCorrBT() by computing GRM genome-wide
 ```{r}
-
 # Running
 DataDir <- GXwasR:::GXwasR_data()
 ResultDir <- tempdir()
 finput <- "GXwasR_example"
-byCHR = FALSE
-REMLalgo = 0
+byCHR <- FALSE
+REMLalgo <- 0
 nitr <- 3
 ncores <- 3
 data("Example_phenofile", package = "GXwasR")
-phenofile <- Example_phenofile #Cannot be NULL, the interested phenotype column should be labeled as
+phenofile <- Example_phenofile # Cannot be NULL, the interested phenotype column should be labeled as
 cat_covarfile <- NULL
 quant_covarfile <- NULL
-partGRM <- FALSE #Partition the GRM into m parts (by row),
-autosome = TRUE
+partGRM <- FALSE # Partition the GRM into m parts (by row),
+autosome <- TRUE
 Xsome <- TRUE
-cripticut = 0.025
+cripticut <- 0.025
 minMAF <- 0.01 # if MAF filter apply
 maxMAF <- 0.04
-excludeResidual = TRUE
-GC <- GeneticCorrBT(DataDir = DataDir, ResultDir = ResultDir, finput = finput, byCHR = byCHR,
-                    REMLalgo = 0, nitr = nitr, phenofile = phenofile, cat_covarfile = NULL, quant_covarfile = NULL, computeGRM = TRUE, grmfile_name = NULL, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3,cripticut = 0.025, minMAF = NULL, maxMAF = NULL,excludeResidual = TRUE, ncores = ncores)
-##Genetic correlation from the last iteration. In this example there was no rg value since the program stopped after nitr-1 = 2 iteration due to convergence issue.
+excludeResidual <- TRUE
+GC <- GeneticCorrBT(
+    DataDir = DataDir, ResultDir = ResultDir, finput = finput, byCHR = byCHR,
+    REMLalgo = 0, nitr = nitr, phenofile = phenofile, cat_covarfile = NULL, quant_covarfile = NULL, computeGRM = TRUE, grmfile_name = NULL, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3, cripticut = 0.025, minMAF = NULL, maxMAF = NULL, excludeResidual = TRUE, ncores = ncores
+)
+## Genetic correlation from the last iteration. In this example there was no rg value since the program stopped after nitr-1 = 2 iteration due to convergence issue.
 GC
 ```
 
 ## Running GeneticCorrBT() using precomputed genome-wide GRM 
 ```{r}
+byCHR <- FALSE
+computeGRM <- FALSE
+grmfile_name <- "GXwasR"
 
-byCHR = FALSE
-computeGRM = FALSE
-grmfile_name = "GXwasR"
-
-GC <- GeneticCorrBT(DataDir = DataDir, ResultDir = ResultDir, finput = finput, byCHR = byCHR,
-                    REMLalgo = 0, nitr = nitr, phenofile = phenofile, cat_covarfile = NULL, quant_covarfile = NULL, computeGRM = FALSE, grmfile_name = grmfile_name, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3,cripticut = 0.025, minMAF = NULL, maxMAF = NULL,excludeResidual = TRUE, ncores = ncores)
-##Genetic correlation from the last iteration. In this example there was no rg value since the program stopped after nitr-1 = 2 iteration due to convergence issue.
+GC <- GeneticCorrBT(
+    DataDir = DataDir, ResultDir = ResultDir, finput = finput, byCHR = byCHR,
+    REMLalgo = 0, nitr = nitr, phenofile = phenofile, cat_covarfile = NULL, quant_covarfile = NULL, computeGRM = FALSE, grmfile_name = grmfile_name, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3, cripticut = 0.025, minMAF = NULL, maxMAF = NULL, excludeResidual = TRUE, ncores = ncores
+)
+## Genetic correlation from the last iteration. In this example there was no rg value since the program stopped after nitr-1 = 2 iteration due to convergence issue.
 GC
 ```
 
 ## Running GeneticCorrBT() by computing GRM chromosome-wise
 ```{r}
-byCHR = TRUE
-computeGRM = TRUE
-grmfile_name = NULL
+byCHR <- TRUE
+computeGRM <- TRUE
+grmfile_name <- NULL
 
-GC <- GeneticCorrBT(DataDir = DataDir, ResultDir = ResultDir, finput = finput, byCHR = byCHR,
-                    REMLalgo = 0, nitr = nitr, phenofile = phenofile, cat_covarfile = NULL, quant_covarfile = NULL, computeGRM = computeGRM, grmfile_name = grmfile_name, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3,cripticut = 0.025, minMAF = NULL, maxMAF = NULL,excludeResidual = TRUE, ncores = ncores)
+GC <- GeneticCorrBT(
+    DataDir = DataDir, ResultDir = ResultDir, finput = finput, byCHR = byCHR,
+    REMLalgo = 0, nitr = nitr, phenofile = phenofile, cat_covarfile = NULL, quant_covarfile = NULL, computeGRM = computeGRM, grmfile_name = grmfile_name, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3, cripticut = 0.025, minMAF = NULL, maxMAF = NULL, excludeResidual = TRUE, ncores = ncores
+)
 GC
 ```
 
 ## Running GeneticCorrBT() using chromosome-wide pre-computed GRM
 ```{r}
-byCHR = TRUE
-computeGRM = FALSE
-grmfile_name = "GXwasR"
+byCHR <- TRUE
+computeGRM <- FALSE
+grmfile_name <- "GXwasR"
 
-GC <- GeneticCorrBT(DataDir = DataDir, ResultDir = ResultDir, finput = finput, byCHR = byCHR,
-                    REMLalgo = 0, nitr = nitr, phenofile = phenofile, cat_covarfile = NULL, quant_covarfile = NULL, computeGRM = computeGRM, grmfile_name = grmfile_name, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3,cripticut = 0.025, minMAF = NULL, maxMAF = NULL,excludeResidual = TRUE, ncores = ncores)
+GC <- GeneticCorrBT(
+    DataDir = DataDir, ResultDir = ResultDir, finput = finput, byCHR = byCHR,
+    REMLalgo = 0, nitr = nitr, phenofile = phenofile, cat_covarfile = NULL, quant_covarfile = NULL, computeGRM = computeGRM, grmfile_name = grmfile_name, partGRM = FALSE, autosome = TRUE, Xsome = TRUE, nGRM = 3, cripticut = 0.025, minMAF = NULL, maxMAF = NULL, excludeResidual = TRUE, ncores = ncores
+)
 GC
 ```
 

--- a/vignettes/GXwasR_overview.Rmd
+++ b/vignettes/GXwasR_overview.Rmd
@@ -124,7 +124,7 @@ To verify that PLINK is discoverable:
 ```{r}
 plink_path <- Sys.getenv("PLINK_PATH", unset = Sys.which("plink"))
 if (!file.exists(plink_path) || !nzchar(plink_path)) {
-  stop("PLINK binary not found. Please install PLINK and/or set the PLINK_PATH environment variable.")
+    stop("PLINK binary not found. Please install PLINK and/or set the PLINK_PATH environment variable.")
 }
 ```
 
@@ -169,7 +169,7 @@ To verify that GCTA is discoverable:
 ```{r}
 gcta_path <- Sys.getenv("GCTA_PATH", unset = Sys.which("gcta64"))
 if (!file.exists(gcta_path) || !nzchar(gcta_path)) {
-  stop("GCTA binary not found. Please install GCTA and/or set the GCTA_PATH environment variable.")
+    stop("GCTA binary not found. Please install GCTA and/or set the GCTA_PATH environment variable.")
 }
 ```
 

--- a/vignettes/gwas_models.Rmd
+++ b/vignettes/gwas_models.Rmd
@@ -207,9 +207,9 @@ Difftest <- SexDiff(Mfile = x1, Ffile = x2)
 sig.snps <- Difftest[Difftest$adjP < 0.05, ]
 colnames(sig.snps) <- c("SNP", "CHR", "BP", "A1", "T_statistic", "Pvalue", "Adjusted_Pvalue")
 if (nrow(sig.snps) > 0) {
-  knitr::kable(sig.snps, caption = "SNPs with significant sex-differential effect.")
+    knitr::kable(sig.snps, caption = "SNPs with significant sex-differential effect.")
 } else {
-  message("No SNPs with significant sex-differential effect were found.")
+    message("No SNPs with significant sex-differential effect were found.")
 }
 ```
 

--- a/vignettes/meta_analysis.Rmd
+++ b/vignettes/meta_analysis.Rmd
@@ -168,7 +168,7 @@ knitr::kable(x1[1:10, ], caption = "Top ten problematic SNPs.")
 ## Manhattan Plots and QQ plots:
 
 ```{r, meta-manhattan_plot, echo=FALSE, fig.caption = "Manhattan Plot"}
-manhattanPlot <- file.path(ResultDir, 'Meta_Analysis.plot.jpeg')
+manhattanPlot <- file.path(ResultDir, "Meta_Analysis.plot.jpeg")
 outdir <- "figures"
 dir.create(outdir, showWarnings = FALSE)
 outfile <- file.path(outdir, "Meta_Analysis.plot.jpeg")

--- a/vignettes/preimputationQC.Rmd
+++ b/vignettes/preimputationQC.Rmd
@@ -145,13 +145,13 @@ hweCase <- NULL
 hweControl <- NULL
 monomorphicSNPs <- FALSE
 ld_prunning <- FALSE
-x <- QCsnp(DataDir = DataDir, ResultDir = ResultDir, finput = finput,foutput = foutput, geno = geno, maf = maf,hweCase = hweCase, hweControl = hweControl, ld_prunning = ld_prunning, casecontrol = casecontrol, monomorphicSNPs = monomorphicSNPs, caldiffmiss = caldiffmiss, dmissX = dmissX, dmissAutoY = dmissAutoY, diffmissFilter = diffmissFilter)
+x <- QCsnp(DataDir = DataDir, ResultDir = ResultDir, finput = finput, foutput = foutput, geno = geno, maf = maf, hweCase = hweCase, hweControl = hweControl, ld_prunning = ld_prunning, casecontrol = casecontrol, monomorphicSNPs = monomorphicSNPs, caldiffmiss = caldiffmiss, dmissX = dmissX, dmissAutoY = dmissAutoY, diffmissFilter = diffmissFilter)
 ```
 
 Copying the plink files from ResultDir to DataDir.
 ```{r}
-ftemp <- list.files(paste0(ResultDir,"/"),pattern = "PreimputeEX_QC1")
-file.copy(paste0(ResultDir,"/",ftemp),DataDir)
+ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PreimputeEX_QC1")
+file.copy(paste0(ResultDir, "/", ftemp), DataDir)
 PlinkSummary(DataDir, ResultDir, finput = "PreimputeEX_QC1")
 ```
 
@@ -161,18 +161,18 @@ It excludes individuals who have missing genotype data for more than 20% of the 
 # Running
 finput <- "PreimputeEX_QC1"
 foutput <- "PreimputeEX_QC2"
-imiss = 0.2
-het = NULL
-IBD = NULL
+imiss <- 0.2
+het <- NULL
+IBD <- NULL
 filterSample <- TRUE
 ambi_out <- TRUE
-x = QCsample(DataDir = DataDir,ResultDir = ResultDir, finput = finput,foutput = foutput, imiss = imiss,het = het, IBD = NULL, filterSample = filterSample, ambi_out = ambi_out)
+x <- QCsample(DataDir = DataDir, ResultDir = ResultDir, finput = finput, foutput = foutput, imiss = imiss, het = het, IBD = NULL, filterSample = filterSample, ambi_out = ambi_out)
 ```
 
 ## Step 4: Apply sex check
 ```{r}
 finput <- "PreimputeEX_QC1" # Using the same input file
-LD = TRUE
+LD <- TRUE
 LD_window_size <- 50
 LD_step_size <- 5
 LD_r2_threshold <- 0.02
@@ -181,16 +181,16 @@ mmin_F <- 0.7
 # We will not infer sex
 infer_sex <- FALSE
 compute_freq <- FALSE
-SexCheckResult <-SexCheck(DataDir=DataDir,ResultDir = ResultDir, finput=finput, infer_sex = infer_sex,compute_freq =compute_freq,LD_window_size=LD_window_size,LD_step_size=LD_step_size,LD_r2_threshold=0.02,fmax_F = fmax_F,mmin_F=mmin_F)
-problematic_sex <- SexCheckResult[SexCheckResult$STATUS != "OK",]
-problematic_sex <- problematic_sex[,1:2]
+SexCheckResult <- SexCheck(DataDir = DataDir, ResultDir = ResultDir, finput = finput, infer_sex = infer_sex, compute_freq = compute_freq, LD_window_size = LD_window_size, LD_step_size = LD_step_size, LD_r2_threshold = 0.02, fmax_F = fmax_F, mmin_F = mmin_F)
+problematic_sex <- SexCheckResult[SexCheckResult$STATUS != "OK", ]
+problematic_sex <- problematic_sex[, 1:2]
 ```
 
 Number of samples with problematic sex assignment: `r nrow(problematic_sex)`
 
 ```{r}
-write.table(problematic_sex,file = paste0(DataDir,"/problematic_sex_samples"),quote = FALSE, row.names = FALSE,col.names = FALSE)
-SexCheckResult[1:5,]
+write.table(problematic_sex, file = paste0(DataDir, "/problematic_sex_samples"), quote = FALSE, row.names = FALSE, col.names = FALSE)
+SexCheckResult[1:5, ]
 ```
 
 Note, there is no filtering of the samples based on sex prediction.
@@ -210,20 +210,19 @@ Users have the ability to impute the sex for their dataset.
 We prefer to keep only chromosome 1 to 23. 
 
 ```{r}
-test1 <- read.table(paste0(DataDir,"/",finput,".bim"))
+test1 <- read.table(paste0(DataDir, "/", finput, ".bim"))
 unique(test1$V1)
 ```
 ```{r}
 foutput <- "PreimputeEX_QC2"
-x <- FilterRegion(DataDir = DataDir, ResultDir = ResultDir, finput = finput, foutput = foutput, CHRX = FALSE, CHRY = FALSE, filterPAR = FALSE, filterXTR = FALSE, filterAmpliconic = FALSE, regionfile = FALSE, filterCHR = c(24, 25, 26),Hg = "38", exclude = TRUE)
-
+x <- FilterRegion(DataDir = DataDir, ResultDir = ResultDir, finput = finput, foutput = foutput, CHRX = FALSE, CHRY = FALSE, filterPAR = FALSE, filterXTR = FALSE, filterAmpliconic = FALSE, regionfile = FALSE, filterCHR = c(24, 25, 26), Hg = "38", exclude = TRUE)
 ```
 
 Copying the plink files from ResultDir to DataDir.
 
 ```{r}
-ftemp <- list.files(paste0(ResultDir,"/"),pattern = "PreimputeEX_QC2")
-file.copy(paste0(ResultDir,"/",ftemp),DataDir)
+ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PreimputeEX_QC2")
+file.copy(paste0(ResultDir, "/", ftemp), DataDir)
 PlinkSummary(DataDir, ResultDir, finput = "PreimputeEX_QC2")
 ```
 
@@ -242,16 +241,16 @@ dmissX <- TRUE
 dmissAutoY <- TRUE
 monomorphicSNPs <- TRUE
 ld_prunning <- FALSE
-hwe = NULL
+hwe <- NULL
 hweCase <- 1e-10
 hweControl <- 1e-06
-x <- QCsnp(DataDir = DataDir, ResultDir = ResultDir, finput = finput,foutput = foutput, geno = geno, maf = maf,hweCase = hweCase, hweControl = hweControl, ld_prunning = ld_prunning, casecontrol = casecontrol, monomorphicSNPs = monomorphicSNPs, caldiffmiss = caldiffmiss, dmissX = dmissX, dmissAutoY = dmissAutoY, diffmissFilter = diffmissFilter)
+x <- QCsnp(DataDir = DataDir, ResultDir = ResultDir, finput = finput, foutput = foutput, geno = geno, maf = maf, hweCase = hweCase, hweControl = hweControl, ld_prunning = ld_prunning, casecontrol = casecontrol, monomorphicSNPs = monomorphicSNPs, caldiffmiss = caldiffmiss, dmissX = dmissX, dmissAutoY = dmissAutoY, diffmissFilter = diffmissFilter)
 ```
 Copying the plink files from ResultDir to DataDir.
 
 ```{r}
-ftemp <- list.files(paste0(ResultDir,"/"),pattern = "PreimputeEX_QC3")
-file.copy(paste0(ResultDir,"/",ftemp),DataDir)
+ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PreimputeEX_QC3")
+file.copy(paste0(ResultDir, "/", ftemp), DataDir)
 PlinkSummary(DataDir, ResultDir, finput = "PreimputeEX_QC3")
 ```
 
@@ -261,19 +260,19 @@ Here we are using stringent thresholds for sample filter.
 ```{r preimpute-QCSample}
 finput <- "PreimputeEX_QC3"
 foutput <- "PreimputeEX_QC4"
-imiss = 0.02
-het = 3
-IBD = 0.2
-IBDmatrix = FALSE
-small_sample_mod = TRUE
-filterSample = TRUE
-ambi_out = TRUE
-x = QCsample(DataDir = DataDir,ResultDir = ResultDir, finput = finput,foutput = foutput, imiss = imiss,het = het, IBD = IBD, IBDmatrix = IBDmatrix, filterSample = filterSample, ambi_out = ambi_out)
+imiss <- 0.02
+het <- 3
+IBD <- 0.2
+IBDmatrix <- FALSE
+small_sample_mod <- TRUE
+filterSample <- TRUE
+ambi_out <- TRUE
+x <- QCsample(DataDir = DataDir, ResultDir = ResultDir, finput = finput, foutput = foutput, imiss = imiss, het = het, IBD = IBD, IBDmatrix = IBDmatrix, filterSample = filterSample, ambi_out = ambi_out)
 ```
 Copying the plink files from ResultDir to DataDir.
 ```{r}
-ftemp <- list.files(paste0(ResultDir,"/"),pattern = "PreimputeEX_QC4")
-file.copy(paste0(ResultDir,"/",ftemp),DataDir)
+ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PreimputeEX_QC4")
+file.copy(paste0(ResultDir, "/", ftemp), DataDir)
 PlinkSummary(DataDir, ResultDir, finput = "PreimputeEX_QC4")
 ```
 
@@ -288,19 +287,20 @@ finput <- "PreimputeEX_QC4"
 reference <- "HapMapIII_NCBI36"
 highLD_regions <- highLD_hg19
 study_pop <- example_data_study_sample_ancestry
-studyLD_window_size = 50
-studyLD_step_size = 5
-studyLD_r2_threshold = 0.02
-filterSNP = TRUE
-studyLD = TRUE
-referLD = TRUE
-referLD_window_size = 50
-referLD_step_size = 5
-referLD_r2_threshold = 0.02
-outlier = TRUE
-outlier_threshold = 3
-outlierOf = "EUR"
-x <- AncestryCheck(DataDir = DataDir,
+studyLD_window_size <- 50
+studyLD_step_size <- 5
+studyLD_r2_threshold <- 0.02
+filterSNP <- TRUE
+studyLD <- TRUE
+referLD <- TRUE
+referLD_window_size <- 50
+referLD_step_size <- 5
+referLD_r2_threshold <- 0.02
+outlier <- TRUE
+outlier_threshold <- 3
+outlierOf <- "EUR"
+x <- AncestryCheck(
+    DataDir = DataDir,
     ResultDir = ResultDir,
     finput = finput,
     reference = reference,
@@ -317,7 +317,8 @@ x <- AncestryCheck(DataDir = DataDir,
     study_pop = study_pop,
     outlier = TRUE,
     outlierOf = "EUR",
-    outlier_threshold = 3)
+    outlier_threshold = 3
+)
 
 Samples_with_predicted_ancestry <- x[["Samples_with_predicted_ancestry"]]
 
@@ -325,7 +326,7 @@ outlier <- x[["Outlier_samples"]]
 
 outlier
 
-Samples_with_predicted_ancestry[1:5,]
+Samples_with_predicted_ancestry[1:5, ]
 ```
 
 There was no outlier samples.
@@ -345,14 +346,14 @@ dmissX <- TRUE
 dmissAutoY <- TRUE
 monomorphicSNPs <- TRUE
 ld_prunning <- FALSE
- hwe = NULL
+hwe <- NULL
 hweCase <- 1e-10
 hweControl <- 1e-06
-x <- QCsnp(DataDir = ResultDir, ResultDir = ResultDir, finput = finput,foutput = foutput, geno = geno, maf = maf,hweCase = hweCase, hweControl = hweControl, ld_prunning = ld_prunning, casecontrol = casecontrol, monomorphicSNPs = monomorphicSNPs, caldiffmiss = caldiffmiss, dmissX = dmissX, dmissAutoY = dmissAutoY, diffmissFilter = diffmissFilter)
+x <- QCsnp(DataDir = ResultDir, ResultDir = ResultDir, finput = finput, foutput = foutput, geno = geno, maf = maf, hweCase = hweCase, hweControl = hweControl, ld_prunning = ld_prunning, casecontrol = casecontrol, monomorphicSNPs = monomorphicSNPs, caldiffmiss = caldiffmiss, dmissX = dmissX, dmissAutoY = dmissAutoY, diffmissFilter = diffmissFilter)
 ```
 ## Final Summary of final Qc-ed dataset.
 ```{r}
-PlinkSummary(ResultDir,ResultDir,foutput)
+PlinkSummary(ResultDir, ResultDir, foutput)
 ```
 ## Citation
 If you are using GXwasR package and/or following this pipeline in your study, please cite it as:

--- a/vignettes/preimputationQC.Rmd
+++ b/vignettes/preimputationQC.Rmd
@@ -189,7 +189,7 @@ problematic_sex <- problematic_sex[,1:2]
 Number of samples with problematic sex assignment: `r nrow(problematic_sex)`
 
 ```{r}
-write.table(problematic_sex,file = paste0(DataDir,"/problematic_sex_samples"),quote = F, row.names = F,col.names = F)
+write.table(problematic_sex,file = paste0(DataDir,"/problematic_sex_samples"),quote = FALSE, row.names = FALSE,col.names = FALSE)
 SexCheckResult[1:5,]
 ```
 


### PR DESCRIPTION
## Overview

This PR standardizes mathematical notation throughout the package documentation to ensure compatibility with R CMD check and PDF manual generation.

Several .Rd and roxygen2 comment blocks previously contained Unicode math symbols (e.g., ∑, χ, β, Φ, and Unicode minus signs) that caused LaTeX errors during Rd → PDF conversion such as:

```
! LaTeX Error: Unicode character (U+2211)
! LaTeX Error: Unicode character (U+03C7)
```

These symbols have been replaced with proper LaTeX-safe math macros inside `\eqn{}` blocks.

## Additional Changes

Bioc style was applied to new package vignettes