### PR TITLE
QCsample() Fix

### DIFF
--- a/R/GXwasR_main_functions.R
+++ b/R/GXwasR_main_functions.R
@@ -3331,7 +3331,7 @@ QCsample <- function(DataDir,
                 excludeSamplesArgs <- c(
                     "--bfile", normalizePath(file.path(DataDir, finput), mustWork = FALSE),
                     "--make-bed",
-                    "--out", normalizePath(file.path(ResultDir, "foutput"), mustWork = FALSE),
+                    "--out", normalizePath(file.path(ResultDir, foutput), mustWork = FALSE),
                     "--silent"
                 )
                 executePlink(excludeSamplesArgs)
@@ -3384,7 +3384,9 @@ QCsample <- function(DataDir,
                 Missingness_results = fmi,
                 Heterozygosity_results = fhh,
                 IBD_results = ibd,
-                het_plot = het_plot
+                het_plot = if(!is.null(imiss) && !is.null(het)) {
+                    het_plot }
+                    else { NULL }
             ))
         },
         error = function(e) {

--- a/tests/testthat/test-QCSample.R
+++ b/tests/testthat/test-QCSample.R
@@ -25,3 +25,54 @@ test_that("QCsample returns expected output", {
     ))
     unlink(ResultDir, recursive = TRUE)
 })
+
+test_that("QCsample returns foutput when het = NULL", {
+    skip_on_bioc()
+    ## Use example from preimputationQC vignette to ensure 
+    ## all necessary intermediate files are present.  
+    DataDir <- GXwasR:::GXwasR_data()
+    ResultDir <- tempdir()
+    finput <- "GXwasR_example"
+    foutput <- "PreimputeEX_QC1"
+    x <- FilterAllele(DataDir, ResultDir, finput, foutput)
+    foutput <- "PreimputeEX_QC1"
+    geno <- 0.2
+    maf <- NULL
+    casecontrol <- FALSE
+    caldiffmiss <- FALSE
+    diffmissFilter <- FALSE
+    dmissX <- FALSE
+    dmissAutoY <- FALSE
+    monomorphicSNPs <- TRUE
+    ld_prunning <- FALSE
+    casecontrol <- FALSE
+    hweCase <- NULL
+    hweControl <- NULL
+    monomorphicSNPs <- FALSE
+    ld_prunning <- FALSE
+    x <- QCsnp(
+        DataDir = DataDir, ResultDir = ResultDir, finput = finput,
+        foutput = foutput, geno = geno, maf = maf,hweCase = hweCase, 
+        hweControl = hweControl, ld_prunning = ld_prunning, 
+        casecontrol = casecontrol, monomorphicSNPs = monomorphicSNPs, 
+        caldiffmiss = caldiffmiss, dmissX = dmissX, 
+        dmissAutoY = dmissAutoY, diffmissFilter = diffmissFilter
+    )
+    ftemp <- list.files(ResultDir, pattern = "PreimputeEX_QC1", full.names = TRUE)
+    file.copy(ftemp, DataDir)
+    finput <- "PreimputeEX_QC1"
+    foutput <- "PreimputeEX_QC2"
+    imiss <- 0.2
+    het <- NULL
+    IBD <- NULL
+    filterSample <- TRUE
+    ambi_out <- TRUE
+    x = QCsample(
+        DataDir = DataDir,ResultDir = ResultDir, finput = finput,foutput = foutput, 
+        imiss = imiss,het = het, IBD = NULL, filterSample = filterSample, 
+        ambi_out = ambi_out
+    )
+    output_files <- list.files(ResultDir, pattern = foutput)
+    expect_equal(length(output_files), 7)
+    unlink(ResultDir, recursive = TRUE)
+})

--- a/vignettes/postimputationQC.Rmd
+++ b/vignettes/postimputationQC.Rmd
@@ -163,8 +163,8 @@ x <- QCsnp(DataDir = DataDir, ResultDir = ResultDir, finput = finput, foutput = 
 Copying the plink files from ResultDir to DataDir.
 
 ```{r}
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PostimputeEX_QC1")
-file.copy(paste0(ResultDir, "/", ftemp), DataDir)
+ftemp <- list.files(ResultDir, pattern = "PostimputeEX_QC1", full.names = TRUE)
+file.copy(ftemp, DataDir)
 ```
 
 ## Step 3: Flag PAR, XTR and Ampliconic Regions
@@ -180,9 +180,9 @@ x <- FilterRegion(DataDir = DataDir, ResultDir = ResultDir, finput = finput, fou
 XTR_SNPs <- x$XTR
 Ampli_SNPs <- x$Ampliconic
 PAR_SNPs <- x$PAR
-save(XTR_SNPs, file = paste0(ResultDir, "/Postimpute_XTR_SNPs.Rda"))
-save(Ampli_SNPs, file = paste0(ResultDir, "/Postimpute_Ampli_SNPs.Rda"))
-save(PAR_SNPs, file = paste0(ResultDir, "/Postimpute_PAR_SNPs.Rda"))
+save(XTR_SNPs, file = file.path(ResultDir, "Postimpute_XTR_SNPs.Rda"))
+save(Ampli_SNPs, file = file.path(ResultDir, "Postimpute_Ampli_SNPs.Rda"))
+save(PAR_SNPs, file = file.path(ResultDir, "Postimpute_PAR_SNPs.Rda"))
 ```
 
 ```{r}
@@ -212,9 +212,9 @@ Now, users need to move the QC-ed files (i.e., "PostimputeEX_QC2" and “Postimp
 
 Copying the plink files from ResultDir to DataDir.
 
-```{r}
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PostimputeEX_QC2")
-file.copy(paste0(ResultDir, "/", ftemp), DataDir)
+```{r, eval = FALSE}
+ftemp <- list.files(ResultDir, pattern = "PostimputeEX_QC2", full.names = TRUE)
+file.copy(ftemp, DataDir)
 ```
 
 ## Step 5: Preparing autosomal and X-chromosomal plink binary files
@@ -232,8 +232,8 @@ y <- FilterRegion(DataDir = DataDir, ResultDir = ResultDir, finput = finput, fou
 
 ```{r}
 # Now, copying these files to DataDir.
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PostimputeEX_QC3")
-invisible(file.copy(paste0(ResultDir, "/", ftemp), DataDir))
+ftemp <- list.files(ResultDir, pattern = "PostimputeEX_QC3", full.names = TRUE)
+file.copy(ftemp, DataDir)
 ```
 
 **Note: We will not perform step 6, since we do not have any PAR regions. The steps are provided for the users in the case if they have PAR regions in their dataset.**
@@ -281,16 +281,16 @@ Removing the previous QC-ed file from DataDir and copying the new QC-ed file to 
 
 ```{r}
 ## Removing the previous QC-ed file from DataDir and copying the new QC-ed file to DataDir.
-ftemp <- list.files(paste0(DataDir, "/"), pattern = "PostimputeEX_QC1")
-invisible(file.remove(paste0(DataDir, "/", ftemp)))
+ftemp <- list.files(DataDir, pattern = "PostimputeEX_QC1", full.names = TRUE)
+file.remove(ftemp)
 
 ## Removing the previous QC-ed file from DataDir and copying the new QC-ed file to DataDir.
-ftemp <- list.files(paste0(DataDir, "/"), pattern = "PostimputeEX_QC2")
-invisible(file.remove(paste0(DataDir, "/", ftemp)))
+ftemp <- list.files(DataDir, pattern = "PostimputeEX_QC2", full.names = TRUE)
+file.remove(ftemp)
 
 ## Copying new plink files to DataDir
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PostimputeEX_QC4")
-invisible(file.copy(paste0(ResultDir, "/", ftemp), DataDir))
+ftemp <- list.files(ResultDir, pattern = "PostimputeEX_QC4", full.names = TRUE)
+file.copy(ftemp, DataDir)
 ```
 
 ## Step 9: Remove SNPs with MAF < 0.05 from each sex from the sex-specific autosomal plink files
@@ -325,14 +325,14 @@ x <- QCsnp(DataDir = DataDir, ResultDir = ResultDir, finput = finput, foutput = 
 Removing the previous QC-ed file from DataDir and copying the new QC-ed file to DataDir.
 
 ```{r}
-ftemp <- list.files(paste0(DataDir, "/"), pattern = "PostimputeEX_QC4")
-invisible(file.remove(paste0(DataDir, "/", ftemp)))
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PostimputeEX_QC4")
-invisible(file.remove(paste0(ResultDir, "/", ftemp)))
+ftemp <- list.files(DataDir, pattern = "PostimputeEX_QC4", full.names = TRUE)
+file.remove(ftemp)
+ftemp <- list.files(ResultDir, pattern = "PostimputeEX_QC4", full.names = TRUE)
+file.remove(ftemp)
 
 ## Copying the new QC-ed file to DataDir.
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PostimputeEX_QC5")
-invisible(file.copy(paste0(ResultDir, "/", ftemp), DataDir))
+ftemp <- list.files(ResultDir, pattern = "PostimputeEX_QC5", full.names = TRUE)
+file.copy(ftemp, DataDir)
 ```
 
 ## Step 10: Combine sex-specific autosomal QC-ed files using common SNPs:
@@ -347,17 +347,17 @@ y <- MergeRegion(DataDir, ResultDir, finput1, finput2, foutput, use_common_snps 
 Removing the previous QC-ed file from DataDir and copying the new QC-ed file to DataDir.
 
 ```{r}
-ftemp <- list.files(paste0(DataDir, "/"), pattern = "PostimputeEX_QC5")
-invisible(file.remove(paste0(DataDir, "/", ftemp)))
+ftemp <- list.files(DataDir, pattern = "PostimputeEX_QC5", full.names = TRUE)
+file.remove(ftemp)
 
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PostimputeEX_Auto")
-invisible(file.copy(paste0(ResultDir, "/", ftemp), DataDir))
+ftemp <- list.files(ResultDir, pattern = "PostimputeEX_Auto", full.names = TRUE)
+file.copy(ftemp, DataDir)
 
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PostimputeEX_QC5")
-invisible(file.remove(paste0(ResultDir, "/", ftemp)))
+ftemp <- list.files(ResultDir, pattern = "PostimputeEX_QC5", full.names = TRUE)
+file.remove(ftemp)
 
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PostimputeEX_Auto")
-invisible(file.remove(paste0(ResultDir, "/", ftemp)))
+ftemp <- list.files(ResultDir, pattern = "PostimputeEX_Auto", full.names = TRUE)
+file.remove(ftemp)
 ```
 
 ## Step 11: Get sex-specific X-chromosomal plink files
@@ -377,8 +377,8 @@ foutput <- "PostimputeEX_QC3_XMale"
 sex <- "males"
 x <- GetMFPlink(DataDir = DataDir, ResultDir = ResultDir, finput = finput, foutput = foutput, sex = sex, xplink = FALSE, autoplink = FALSE)
 ## Copying sex-specific plink files
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PostimputeEX_QC3_X")
-invisible(file.copy(paste0(ResultDir, "/", ftemp), DataDir))
+ftemp <- list.files(ResultDir, pattern = "PostimputeEX_QC3_X", full.names = TRUE)
+file.copy(ftemp, DataDir)
 ```
 
 ## Step 12: QC of sex-specific X-chromosomal SNPs
@@ -411,17 +411,17 @@ x <- QCsnp(DataDir = DataDir, ResultDir = ResultDir, finput = finput, foutput = 
 
 ```{r}
 ## Removing the previous QC-ed file from DataDir and copying the new QC-ed file to DataDir.
-ftemp <- list.files(paste0(DataDir, "/"), pattern = "PostimputeEX_QC3")
-invisible(file.remove(paste0(DataDir, "/", ftemp)))
+ftemp <- list.files(DataDir, pattern = "PostimputeEX_QC3", full.names = TRUE)
+file.remove(ftemp)
 ## Removing the previous QC-ed file from DataDir and copying the new QC-ed file to DataDir.
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PostimputeEX_QC3")
-invisible(file.remove(paste0(ResultDir, "/", ftemp)))
+ftemp <- list.files(ResultDir, pattern = "PostimputeEX_QC3", full.names = TRUE)
+file.remove(ftemp)
 
 ## Copying sex-specific plink files
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PostimputeEX_QC4_X")
-invisible(file.copy(paste0(ResultDir, "/", ftemp), DataDir))
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PostimputeEX_QC4")
-invisible(file.remove(paste0(ResultDir, "/", ftemp)))
+ftemp <- list.files(ResultDir, pattern = "PostimputeEX_QC4_X", full.names = TRUE)
+file.copy(ftemp, DataDir)
+ftemp <- list.files(ResultDir, pattern = "PostimputeEX_QC4", full.names = TRUE)
+file.remove(ftemp)
 ```
 
 ## Step 13: Combine sex-specific QC-ed X chromosomal dataset using common SNPs
@@ -435,12 +435,12 @@ y <- MergeRegion(DataDir, ResultDir, finput1, finput2, foutput, use_common_snps 
 
 ```{r}
 ## Copying merged plink files to DataDir
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PostimputeEX_QC5_Xchr")
-invisible(file.copy(paste0(ResultDir, "/", ftemp), DataDir))
-invisible(file.remove(paste0(ResultDir, "/", ftemp)))
+ftemp <- list.files(ResultDir, pattern = "PostimputeEX_QC5_Xchr", full.names = TRUE)
+file.copy(ftemp, DataDir)
+file.remove(ftemp)
 ## Removing other QC-ed files from DataDir
-ftemp <- list.files(paste0(DataDir, "/"), pattern = "PostimputeEX_QC4")
-invisible(file.remove(paste0(DataDir, "/", ftemp)))
+ftemp <- list.files(DataDir, pattern = "PostimputeEX_QC4", full.names = TRUE)
+file.remove(ftemp)
 ```
 
 ## Step 14: Test for HWE across the X chromosomes in females
@@ -461,12 +461,12 @@ x
 
 ```{r}
 ## Removing the previous QC-ed file from DataDir and copying the new QC-ed file to DataDir.
-ftemp <- list.files(paste0(DataDir, "/"), pattern = "PostimputeEX_QC5_Xchr")
-invisible(file.remove(paste0(DataDir, "/", ftemp)))
+ftemp <- list.files(DataDir, pattern = "PostimputeEX_QC5_Xchr", full.names = TRUE)
+file.remove(ftemp)
 
 ## Copying new QC-ed plink files to DataDir
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PostimputeEX_Xchr")
-invisible(file.copy(paste0(ResultDir, "/", ftemp), DataDir))
+ftemp <- list.files(ResultDir, pattern = "PostimputeEX_Xchr", full.names = TRUE)
+file.copy(ftemp, DataDir)
 ```
 
 ## Step 15: Checking for X-chromosomal SNPs having MAF difference in sexes in controls
@@ -492,12 +492,12 @@ y <- MergeRegion(DataDir, ResultDir, finput1, finput2, foutput, use_common_snps 
 
 ```{r}
 ## Removing the previous QC-ed file from DataDir and copying the new QC-ed file to DataDir.
-ftemp <- list.files(paste0(DataDir, "/"), pattern = "PostimputeEX")
-invisible(file.remove(paste0(DataDir, "/", ftemp)))
+ftemp <- list.files(DataDir, pattern = "PostimputeEX", full.names = TRUE)
+file.remove(ftemp)
 
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "PostimputeQC")
-invisible(file.copy(paste0(ResultDir, "/", ftemp), DataDir))
-invisible(file.remove(paste0(ResultDir, "/", ftemp)))
+ftemp <- list.files(ResultDir, pattern = "PostimputeQC", full.names = TRUE)
+file.copy(ftemp, DataDir)
+file.remove(ftemp)
 ```
 
 ## Step 17: Preparing separate male and female genotype dataset for sample level QC
@@ -518,13 +518,13 @@ x <- GetMFPlink(DataDir = DataDir, ResultDir = ResultDir, finput = finput, foutp
 
 ```{r}
 ## Copying sex-specific plink files to DataDir
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "Postimpute_Female")
-invisible(file.copy(paste0(ResultDir, "/", ftemp), DataDir))
-invisible(file.remove(paste0(ResultDir, "/", ftemp)))
+ftemp <- list.files(ResultDir, pattern = "Postimpute_Female", full.names = TRUE)
+file.copy(ftemp, DataDir)
+file.remove(ftemp)
 
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "Postimpute_Male")
-invisible(file.copy(paste0(ResultDir, "/", ftemp), DataDir))
-invisible(file.remove(paste0(ResultDir, "/", ftemp)))
+ftemp <- list.files(ResultDir, pattern = "Postimpute_Male", full.names = TRUE)
+file.copy(ftemp, DataDir)
+file.remove(ftemp)
 ```
 
 ## Step 18: Sex-specific sample level QC
@@ -558,9 +558,9 @@ x <- QCsample(DataDir = DataDir, ResultDir = ResultDir, small_sample_mod = small
 
 ```{r}
 ## Copying filtered plink files to DataDir
-ftemp <- list.files(paste0(ResultDir, "/"), pattern = "Postimpute_")
-invisible(file.copy(paste0(ResultDir, "/", ftemp), DataDir))
-invisible(file.remove(paste0(ResultDir, "/", ftemp)))
+ftemp <- list.files(ResultDir, pattern = "Postimpute_", full.names = TRUE)
+file.copy(ftemp, DataDir)
+file.remove(ftemp)
 ```
 
 ## Step 19: Combine male and female-specific Qc-ed genotype datasets
@@ -575,8 +575,8 @@ y <- MergeRegion(DataDir, ResultDir, finput1, finput2, foutput, use_common_snps 
 
 ```{r}
 ## Removing the not needed files from DataDir.
-ftemp <- list.files(paste0(DataDir, "/"), pattern = "Postimpute_")
-invisible(file.remove(paste0(DataDir, "/", ftemp)))
+ftemp <- list.files(DataDir, pattern = "Postimpute_", full.names = TRUE)
+file.remove(ftemp)
 ```
 
 # Final Summary of the final QC-ed genotype dataset

--- a/vignettes/preimputationQC.Rmd
+++ b/vignettes/preimputationQC.Rmd
@@ -150,20 +150,21 @@ x <- QCsnp(DataDir = DataDir, ResultDir = ResultDir, finput = finput,foutput = f
 
 Copying the plink files from ResultDir to DataDir.
 ```{r}
-ftemp <- list.files(paste0(ResultDir,"/"),pattern = "PreimputeEX_QC1")
-file.copy(paste0(ResultDir,"/",ftemp),DataDir)
+ftemp <- list.files(ResultDir, pattern = "PreimputeEX_QC1", full.names = TRUE)
+file.copy(ftemp, DataDir)
 PlinkSummary(DataDir, ResultDir, finput = "PreimputeEX_QC1")
 ```
 
 ## Step 3: Filtering samples with high missing rate threshold.
 It excludes individuals who have missing genotype data for more than 20% of the genetic variants in the dataset.
+
 ```{r}
 # Running
 finput <- "PreimputeEX_QC1"
 foutput <- "PreimputeEX_QC2"
-imiss = 0.2
-het = NULL
-IBD = NULL
+imiss <- 0.2
+het <- NULL
+IBD <- NULL
 filterSample <- TRUE
 ambi_out <- TRUE
 x = QCsample(DataDir = DataDir,ResultDir = ResultDir, finput = finput,foutput = foutput, imiss = imiss,het = het, IBD = NULL, filterSample = filterSample, ambi_out = ambi_out)
@@ -172,7 +173,7 @@ x = QCsample(DataDir = DataDir,ResultDir = ResultDir, finput = finput,foutput = 
 ## Step 4: Apply sex check
 ```{r}
 finput <- "PreimputeEX_QC1" # Using the same input file
-LD = TRUE
+LD <- TRUE
 LD_window_size <- 50
 LD_step_size <- 5
 LD_r2_threshold <- 0.02
@@ -189,7 +190,7 @@ problematic_sex <- problematic_sex[,1:2]
 Number of samples with problematic sex assignment: `r nrow(problematic_sex)`
 
 ```{r}
-write.table(problematic_sex,file = paste0(DataDir,"/problematic_sex_samples"),quote = F, row.names = F,col.names = F)
+write.table(problematic_sex,file = file.path(DataDir, "problematic_sex_samples"), quote = FALSE, row.names = F, col.names = FALSE)
 SexCheckResult[1:5,]
 ```
 
@@ -210,7 +211,7 @@ Users have the ability to impute the sex for their dataset.
 We prefer to keep only chromosome 1 to 23. 
 
 ```{r}
-test1 <- read.table(paste0(DataDir,"/",finput,".bim"))
+test1 <- read.table(file.path(DataDir,paste0(finput,".bim")))
 unique(test1$V1)
 ```
 ```{r}
@@ -222,15 +223,14 @@ x <- FilterRegion(DataDir = DataDir, ResultDir = ResultDir, finput = finput, fou
 Copying the plink files from ResultDir to DataDir.
 
 ```{r}
-ftemp <- list.files(paste0(ResultDir,"/"),pattern = "PreimputeEX_QC2")
-file.copy(paste0(ResultDir,"/",ftemp),DataDir)
+ftemp <- list.files(ResultDir, pattern = "PreimputeEX_QC2", full.names = TRUE)
+file.copy(ftemp, DataDir)
 PlinkSummary(DataDir, ResultDir, finput = "PreimputeEX_QC2")
 ```
 
 ## Step 6: Second round of SNP filtering.
 
 ```{r}
-library(GXwasR)
 finput <- "PreimputeEX_QC2"
 foutput <- "PreimputeEX_QC3"
 geno <- 0.02
@@ -242,38 +242,42 @@ dmissX <- TRUE
 dmissAutoY <- TRUE
 monomorphicSNPs <- TRUE
 ld_prunning <- FALSE
-hwe = NULL
+hwe <- NULL
 hweCase <- 1e-10
 hweControl <- 1e-06
 x <- QCsnp(DataDir = DataDir, ResultDir = ResultDir, finput = finput,foutput = foutput, geno = geno, maf = maf,hweCase = hweCase, hweControl = hweControl, ld_prunning = ld_prunning, casecontrol = casecontrol, monomorphicSNPs = monomorphicSNPs, caldiffmiss = caldiffmiss, dmissX = dmissX, dmissAutoY = dmissAutoY, diffmissFilter = diffmissFilter)
 ```
+
 Copying the plink files from ResultDir to DataDir.
 
 ```{r}
-ftemp <- list.files(paste0(ResultDir,"/"),pattern = "PreimputeEX_QC3")
-file.copy(paste0(ResultDir,"/",ftemp),DataDir)
+ftemp <- list.files(ResultDir, pattern = "PreimputeEX_QC3", full.names = TRUE)
+file.copy(ftemp, DataDir)
 PlinkSummary(DataDir, ResultDir, finput = "PreimputeEX_QC3")
 ```
 
 ## Step 7: Second round of sample filtering
+
 Here we are using stringent thresholds for sample filter.
 
 ```{r preimpute-QCSample}
 finput <- "PreimputeEX_QC3"
 foutput <- "PreimputeEX_QC4"
-imiss = 0.02
-het = 3
-IBD = 0.2
-IBDmatrix = FALSE
-small_sample_mod = TRUE
-filterSample = TRUE
-ambi_out = TRUE
+imiss <- 0.02
+het <- 3
+IBD <- 0.2
+IBDmatrix <- FALSE
+small_sample_mod <- TRUE
+filterSample <- TRUE
+ambi_out <- TRUE
 x = QCsample(DataDir = DataDir,ResultDir = ResultDir, finput = finput,foutput = foutput, imiss = imiss,het = het, IBD = IBD, IBDmatrix = IBDmatrix, filterSample = filterSample, ambi_out = ambi_out)
 ```
+
 Copying the plink files from ResultDir to DataDir.
+
 ```{r}
-ftemp <- list.files(paste0(ResultDir,"/"),pattern = "PreimputeEX_QC4")
-file.copy(paste0(ResultDir,"/",ftemp),DataDir)
+ftemp <- list.files(ResultDir, pattern = "PreimputeEX_QC4", full.names = TRUE)
+file.copy(ftemp, DataDir)
 PlinkSummary(DataDir, ResultDir, finput = "PreimputeEX_QC4")
 ```
 
@@ -288,18 +292,18 @@ finput <- "PreimputeEX_QC4"
 reference <- "HapMapIII_NCBI36"
 highLD_regions <- highLD_hg19
 study_pop <- example_data_study_sample_ancestry
-studyLD_window_size = 50
-studyLD_step_size = 5
-studyLD_r2_threshold = 0.02
-filterSNP = TRUE
-studyLD = TRUE
-referLD = TRUE
-referLD_window_size = 50
-referLD_step_size = 5
-referLD_r2_threshold = 0.02
-outlier = TRUE
-outlier_threshold = 3
-outlierOf = "EUR"
+studyLD_window_size <-0 50
+studyLD_step_size <- 5
+studyLD_r2_threshold <- 0.02
+filterSNP <- TRUE
+studyLD <- TRUE
+referLD <- TRUE
+referLD_window_size <- 50
+referLD_step_size <- 5
+referLD_r2_threshold <- 0.02
+outlier <- TRUE
+outlier_threshold <- 3
+outlierOf <- "EUR"
 x <- AncestryCheck(DataDir = DataDir,
     ResultDir = ResultDir,
     finput = finput,
@@ -331,9 +335,10 @@ Samples_with_predicted_ancestry[1:5,]
 There was no outlier samples.
 
 ## Step 9: Third round of SNP filtering
+
 To make sure all the filtering thresholds for SNPs are maintained after sample filtering.
+
 ```{r}
-library(GXwasR)
 finput <- "PreimputeEX_QC4"
 foutput <- "Preimpute_Final"
 geno <- 0.02
@@ -345,15 +350,18 @@ dmissX <- TRUE
 dmissAutoY <- TRUE
 monomorphicSNPs <- TRUE
 ld_prunning <- FALSE
- hwe = NULL
+hwe <- NULL
 hweCase <- 1e-10
 hweControl <- 1e-06
 x <- QCsnp(DataDir = ResultDir, ResultDir = ResultDir, finput = finput,foutput = foutput, geno = geno, maf = maf,hweCase = hweCase, hweControl = hweControl, ld_prunning = ld_prunning, casecontrol = casecontrol, monomorphicSNPs = monomorphicSNPs, caldiffmiss = caldiffmiss, dmissX = dmissX, dmissAutoY = dmissAutoY, diffmissFilter = diffmissFilter)
 ```
+
 ## Final Summary of final Qc-ed dataset.
+
 ```{r}
 PlinkSummary(ResultDir,ResultDir,foutput)
 ```
+
 ## Citation
 If you are using GXwasR package and/or following this pipeline in your study, please cite it as:
 ```{r}


### PR DESCRIPTION
## Overview

Fix QCsample() when `het <- NULL` as in the preimputationQC vignette

## Details

Pass `foutput` param to PLINK instead of "foutput" to ensure output file is written to the `ResultDir`. A test was added to verify that output files are produced when this parameter is NULL. Additionally, vignette pathing was cleaned up. 

Fixes #55 